### PR TITLE
Aggregated sf sc scores

### DIFF
--- a/sql_v3_scheduled-on-BigQuery/update_whalesafe_v3_operator_stats_annual.sql
+++ b/sql_v3_scheduled-on-BigQuery/update_whalesafe_v3_operator_stats_annual.sql
@@ -1,142 +1,218 @@
--- # -- # Updating `whalesafe_v3.operator_stats_annual` -- # --
+-- # -- # Updating `whalsafe_v3.operator_stats_annual` -- # --
 -- # Benioff Ocean Initiative: 2020-07-30
 -- # -- # Needs `ship_stats_daily` to run.
-
 -- # -- Step 0: Drop existing table.
-DROP TABLE IF EXISTS `whalesafe_v3.operator_stats_annual`;
-
+DROP 
+  TABLE IF EXISTS `whalsafe_v3.operator_stats_annual`;
 -- # -- Step 1: Create new operator_stats_annual table.
-CREATE TABLE IF NOT EXISTS `whalesafe_v3.operator_stats_annual` CLUSTER BY
-		operator,
-		operator_ship_categories,
-		year,
-		coop_score_annual AS
-    SELECT
-			operator,
-			operator_code,
-      operator_ship_categories,
-      vsr_region,
-			year,
-			ROUND(coop_score, 2) AS coop_score_annual ,
-			CONCAT(
-			ROUND(coop_score, 2), '%', ' ', '(', year, ')') AS cooperation_score_annual,
-			CASE WHEN coop_score >= 99 THEN
-				'A+'
-			WHEN coop_score < 99
-				AND coop_score >= 80 THEN
-				'A'
-			WHEN coop_score < 80
-				AND coop_score >= 60 THEN
-				'B'
-			WHEN coop_score < 60
-				AND coop_score >= 40 THEN
-				'C'
-			WHEN coop_score < 40
-				AND coop_score >= 20 THEN
-				'D'
-			ELSE
-				'F'
-			END AS year_grade ,
-      ROUND(((ROUND(SUM(total_distance_nm_under_10) OVER (PARTITION BY operator, vsr_region ORDER BY operator, year), 2) /ROUND(SUM(total_distance_nm) OVER (PARTITION BY operator, vsr_region ORDER BY operator, year), 2))*100), 2) AS rolling_coop_score,
-      year_ship_count,
-			ROUND(total_distance_nm, 2) AS total_distance_nm,
-     	ROUND(SUM(total_distance_nm) OVER (PARTITION BY operator, vsr_region ORDER BY operator, year), 2) AS cum_sum_total_distance_nm,
-			ROUND(total_distance_nm_under_10, 2) AS total_distance_nm_under_10,
-      ROUND(SUM(total_distance_nm_under_10) OVER (PARTITION BY operator, vsr_region ORDER BY operator, year), 2) AS cum_sum_total_distance_nm_under_10,
-			ROUND(total_distance_nm_btwn_10_12, 2) AS total_distance_nm_btwn_10_12,
-			ROUND(total_distance_nm_btwn_12_15, 2) AS total_distance_nm_btwn_12_15,
-			ROUND(total_distance_nm_over_15, 2) AS total_distance_nm_over_15,
-			ROUND(avg_speed_knots, 2) AS avg_speed_knots,
-			ship_categories_list,
-			mmsi_list,
-			name_of_ships,
-      max_timestamp ,
-      min_timestamp ,
-      include_exclude_category AS exclude_category
-		FROM (
-			SELECT
-				*,
-				(total_distance_nm_under_10 / total_distance_nm) * 100 AS coop_score,
-			FROM (
-				SELECT
-					operator,
-					operator_code,
-          vsr_region,
-					EXTRACT(year FROM date) AS year,
-					COUNT(DISTINCT (mmsi)) AS year_ship_count,
-					SUM(total_distance_nm) AS total_distance_nm,
-					SUM(total_distance_nm_under_10) AS total_distance_nm_under_10,
-					SUM(total_distance_nm_btwn_10_12) AS total_distance_nm_btwn_10_12,
-					SUM(total_distance_nm_btwn_12_15) AS total_distance_nm_btwn_12_15,
-					SUM(total_distance_nm_over_15) AS total_distance_nm_over_15,
-					(SUM(avg_speed_knots)/COUNT(day_count)) AS avg_speed_knots,
-          MAX( max_timestamp ) AS max_timestamp ,
-          MIN( min_timestamp ) AS min_timestamp ,
-					STRING_AGG(DISTINCT(CAST(mmsi AS STRING)), ', ') AS mmsi_list,
-					STRING_AGG(DISTINCT (shiptype), ', ') AS ship_types,
-					STRING_AGG(DISTINCT (name_of_ship), ', ') AS name_of_ships,
-					STRING_AGG(DISTINCT (ship_category), ', ') AS ship_categories_list,
-					CASE WHEN COUNT(DISTINCT (ship_category)) > 1 THEN
-						'multi-category'
-					WHEN COUNT(DISTINCT (ship_category)) = 1 THEN
-						STRING_AGG(DISTINCT (ship_category))
-					END AS operator_ship_categories,
-          CASE WHEN
-          COUNT(DISTINCT (exclude_category)) = 1
-          AND
-          STRING_AGG(DISTINCT(CAST(exclude_category AS STRING)), '') LIKE '%0%'
-          THEN
-						0
-          WHEN
-          COUNT(DISTINCT (exclude_category)) > 1
-          AND STRING_AGG(DISTINCT(CAST(exclude_category AS STRING)), '') LIKE '%01%'
-          THEN
-						0
-          WHEN
-          COUNT(DISTINCT (exclude_category)) > 1
-          AND STRING_AGG(DISTINCT(CAST(exclude_category AS STRING)), '') LIKE '%10%'
-          THEN
-						0
-          WHEN
-          COUNT(DISTINCT (exclude_category)) = 1
-          AND
-          STRING_AGG(DISTINCT(CAST(exclude_category AS STRING)), '') LIKE '%1%'
-          THEN
-            1
-					END AS include_exclude_category
-          FROM
-					`whalesafe_v3.ship_stats_daily`
-          WHERE vsr_category NOT LIKE '%off%'
-				GROUP BY
-					operator,
-					operator_code,
-          vsr_region,
-					year
-          )
-          )
-          ;
-
--- # -- Step 2: Create a timestamp log to track newest timestamps in stats data.
-CREATE TABLE IF NOT EXISTS `whalesafe_v3.stats_log` (
-      newest_timestamp TIMESTAMP,
-      newest_date DATE,
-			date_accessed TIMESTAMP,
-			table_name STRING);
-
--- # -- Step 3: Insert newest timestamp into log
-INSERT INTO `whalesafe_v3.stats_log`
-SELECT
-	(
-		SELECT
-			MAX(max_timestamp)
-		FROM
-			`whalesafe_v3.operator_stats_annual`
-		LIMIT 1) AS newest_timestamp,
+CREATE TABLE IF NOT EXISTS `whalsafe_v3.operator_stats_annual` CLUSTER BY operator, 
+operator_ship_categories, 
+year, 
+coop_score_annual AS 
+SELECT 
+  operator, 
+  operator_code, 
+  operator_ship_categories, 
+  vsr_region, 
+  year, 
+  ROUND(coop_score, 2) AS coop_score_annual, 
+  CONCAT(
+    ROUND(coop_score, 2), 
+    '%', 
+    ' ', 
+    '(', 
+    year, 
+    ')'
+  ) AS cooperation_score_annual, 
+  CASE WHEN coop_score >= 99 THEN 'A+' WHEN coop_score < 99 
+  AND coop_score >= 80 THEN 'A' WHEN coop_score < 80 
+  AND coop_score >= 60 THEN 'B' WHEN coop_score < 60 
+  AND coop_score >= 40 THEN 'C' WHEN coop_score < 40 
+  AND coop_score >= 20 THEN 'D' ELSE 'F' END AS year_grade, 
+  ROUND(
     (
-		SELECT
-			DATE(MAX(max_timestamp))
-		FROM
-			`whalesafe_v3.operator_stats_annual`
-		LIMIT 1) AS newest_date,
-	CURRENT_TIMESTAMP() AS date_accessed,
-	'operator_stats_annual' AS table_name;
+      (
+        ROUND(
+          SUM(total_distance_nm_under_10) OVER (
+            PARTITION BY operator, 
+            vsr_region 
+            ORDER BY 
+              operator, 
+              year
+          ), 
+          2
+        ) / ROUND(
+          SUM(total_distance_nm) OVER (
+            PARTITION BY operator, 
+            vsr_region 
+            ORDER BY 
+              operator, 
+              year
+          ), 
+          2
+        )
+      )* 100
+    ), 
+    2
+  ) AS rolling_coop_score, 
+  year_ship_count, 
+  ROUND(total_distance_nm, 2) AS total_distance_nm, 
+  ROUND(
+    SUM(total_distance_nm) OVER (
+      PARTITION BY operator, 
+      vsr_region 
+      ORDER BY 
+        operator, 
+        year
+    ), 
+    2
+  ) AS cum_sum_total_distance_nm, 
+  ROUND(total_distance_nm_under_10, 2) AS total_distance_nm_under_10, 
+  ROUND(
+    SUM(total_distance_nm_under_10) OVER (
+      PARTITION BY operator, 
+      vsr_region 
+      ORDER BY 
+        operator, 
+        year
+    ), 
+    2
+  ) AS cum_sum_total_distance_nm_under_10, 
+  ROUND(total_distance_nm_btwn_10_12, 2) AS total_distance_nm_btwn_10_12, 
+  ROUND(total_distance_nm_btwn_12_15, 2) AS total_distance_nm_btwn_12_15, 
+  ROUND(total_distance_nm_over_15, 2) AS total_distance_nm_over_15, 
+  ROUND(avg_speed_knots, 2) AS avg_speed_knots, 
+  ship_categories_list, 
+  mmsi_list, 
+  name_of_ships, 
+  max_timestamp, 
+  min_timestamp, 
+  include_exclude_category AS exclude_category 
+FROM 
+  (
+    SELECT 
+      *, 
+      (
+        total_distance_nm_under_10 / total_distance_nm
+      ) * 100 AS coop_score, 
+    FROM 
+      (
+        SELECT 
+          operator, 
+          operator_code, 
+          vsr_region, 
+          EXTRACT(
+            year 
+            FROM 
+              date
+          ) AS year, 
+          COUNT(
+            DISTINCT (mmsi)
+          ) AS year_ship_count, 
+          SUM(total_distance_nm) AS total_distance_nm, 
+          SUM(total_distance_nm_under_10) AS total_distance_nm_under_10, 
+          SUM(total_distance_nm_btwn_10_12) AS total_distance_nm_btwn_10_12, 
+          SUM(total_distance_nm_btwn_12_15) AS total_distance_nm_btwn_12_15, 
+          SUM(total_distance_nm_over_15) AS total_distance_nm_over_15, 
+          (
+            SUM(avg_speed_knots)/ COUNT(day_count)
+          ) AS avg_speed_knots, 
+          MAX(max_timestamp) AS max_timestamp, 
+          MIN(min_timestamp) AS min_timestamp, 
+          STRING_AGG(
+            DISTINCT(
+              CAST(mmsi AS STRING)
+            ), 
+            ', '
+          ) AS mmsi_list, 
+          STRING_AGG(
+            DISTINCT (shiptype), 
+            ', '
+          ) AS ship_types, 
+          STRING_AGG(
+            DISTINCT (name_of_ship), 
+            ', '
+          ) AS name_of_ships, 
+          STRING_AGG(
+            DISTINCT (ship_category), 
+            ', '
+          ) AS ship_categories_list, 
+          CASE WHEN COUNT(
+            DISTINCT (ship_category)
+          ) > 1 THEN 'multi-category' WHEN COUNT(
+            DISTINCT (ship_category)
+          ) = 1 THEN STRING_AGG(
+            DISTINCT (ship_category)
+          ) END AS operator_ship_categories, 
+          CASE WHEN COUNT(
+            DISTINCT (exclude_category)
+          ) = 1 
+          AND STRING_AGG(
+            DISTINCT(
+              CAST(exclude_category AS STRING)
+            ), 
+            ''
+          ) LIKE '%0%' THEN 0 WHEN COUNT(
+            DISTINCT (exclude_category)
+          ) > 1 
+          AND STRING_AGG(
+            DISTINCT(
+              CAST(exclude_category AS STRING)
+            ), 
+            ''
+          ) LIKE '%01%' THEN 0 WHEN COUNT(
+            DISTINCT (exclude_category)
+          ) > 1 
+          AND STRING_AGG(
+            DISTINCT(
+              CAST(exclude_category AS STRING)
+            ), 
+            ''
+          ) LIKE '%10%' THEN 0 WHEN COUNT(
+            DISTINCT (exclude_category)
+          ) = 1 
+          AND STRING_AGG(
+            DISTINCT(
+              CAST(exclude_category AS STRING)
+            ), 
+            ''
+          ) LIKE '%1%' THEN 1 END AS include_exclude_category 
+        FROM 
+          `whalsafe_v3.ship_stats_daily` 
+        WHERE 
+          vsr_category NOT LIKE '%off%' 
+        GROUP BY 
+          operator, 
+          operator_code, 
+          vsr_region, 
+          year
+      )
+  );
+-- # -- Step 2: Create a timestamp log to track newest timestamps in stats data.
+CREATE TABLE IF NOT EXISTS `whalsafe_v3.stats_log` (
+  newest_timestamp TIMESTAMP, newest_date DATE, 
+  date_accessed TIMESTAMP, table_name STRING
+);
+-- # -- Step 3: Insert newest timestamp into log
+INSERT INTO `whalsafe_v3.stats_log` 
+SELECT 
+  (
+    SELECT 
+      MAX(max_timestamp) 
+    FROM 
+      `whalsafe_v3.operator_stats_annual` 
+    LIMIT 
+      1
+  ) AS newest_timestamp, 
+  (
+    SELECT 
+      DATE(
+        MAX(max_timestamp)
+      ) 
+    FROM 
+      `whalsafe_v3.operator_stats_annual` 
+    LIMIT 
+      1
+  ) AS newest_date, 
+  CURRENT_TIMESTAMP() AS date_accessed, 
+  'operator_stats_annual' AS table_name;

--- a/sql_v3_scheduled-on-BigQuery/update_whalesafe_v3_operator_stats_daily.sql
+++ b/sql_v3_scheduled-on-BigQuery/update_whalesafe_v3_operator_stats_daily.sql
@@ -1,193 +1,257 @@
--- # -- # Updating `whalesafe_v3.operator_stats_daily` -- # --
+-- # -- # Updating `whalsafe_v3.operator_stats_daily` -- # --
 -- # Benioff Ocean Initiative: 2020-07-30
 -- # -- # NEEDS `ship_stats_daily` to run.
-
 -- # -- Step 0: Drop existing table
-DROP TABLE IF EXISTS `whalesafe_v3.operator_stats_daily`;
-
+DROP 
+  TABLE IF EXISTS `whalsafe_v3.operator_stats_daily`;
 -- -- -- -- # -- Step 1: Create updated operator_stats_daily table
-CREATE TABLE IF NOT EXISTS `whalesafe_v3.operator_stats_daily` CLUSTER BY
-		operator,
-		operator_ship_categories,
-		date,
-		coop_score_daily AS
-    SELECT
-    operator,
-    operator_code,
-    operator_ship_categories,
-    date,
-    vsr_region,
-    coop_score_daily,
-    day_grade,
-    rolling_coop_score,
-    rolling_day_grade,
-    daily_ship_count,
-    total_distance_nm,
-    cum_sum_total_distance_nm,
-    total_distance_nm_under_10,
-    cum_sum_total_distance_nm_under_10,
-    total_distance_nm_btwn_10_12,
-    total_distance_nm_btwn_12_15,
-    total_distance_nm_over_15,
-    avg_speed_knots,
-    ship_categories_list,
-    mmsi_list,
-    name_of_ships,
-    max_timestamp,
-    min_timestamp,
-    exclude_category,
-    vsr_category
-    FROM(
-    SELECT
-    CASE WHEN rolling_coop_score >= 99 THEN
-				'A+'
-			WHEN rolling_coop_score < 99
-				AND rolling_coop_score >= 80 THEN
-				'A'
-			WHEN rolling_coop_score < 80
-				AND rolling_coop_score >= 60 THEN
-				'B'
-			WHEN rolling_coop_score < 60
-				AND rolling_coop_score >= 40 THEN
-				'C'
-			WHEN rolling_coop_score < 40
-				AND rolling_coop_score >= 20 THEN
-				'D'
-			ELSE
-				'F'
-			END AS rolling_day_grade,
-    *
-    FROM(
-    SELECT
-			operator,
-			operator_code,
-      operator_ship_categories,
-			date,
-      vsr_region,
-			ROUND(
-			coop_score, 2) AS coop_score_daily ,
-      CASE WHEN coop_score >= 99 THEN
-				'A+'
-			WHEN coop_score < 99
-				AND coop_score >= 80 THEN
-				'A'
-			WHEN coop_score < 80
-				AND coop_score >= 60 THEN
-				'B'
-			WHEN coop_score < 60
-				AND coop_score >= 40 THEN
-				'C'
-			WHEN coop_score < 40
-				AND coop_score >= 20 THEN
-				'D'
-			ELSE
-				'F'
-			END AS day_grade,
-			ROUND((SAFE_DIVIDE((SUM(total_distance_nm_under_10) OVER (PARTITION BY operator, vsr_region, year ORDER BY date, year)) , (SUM(total_distance_nm) OVER (PARTITION BY operator, vsr_region, year ORDER BY date, year)))*100), 2) AS rolling_coop_score,
-			daily_ship_count,
-			ROUND(total_distance_nm, 2)            AS total_distance_nm,
-      ROUND(SUM(total_distance_nm) OVER (PARTITION BY operator, vsr_region, year ORDER BY date, year), 2) AS cum_sum_total_distance_nm,
-			ROUND(total_distance_nm_under_10, 2)   AS total_distance_nm_under_10,
-      ROUND(SUM(total_distance_nm_under_10) OVER (PARTITION BY operator, vsr_region, year ORDER BY date, year), 2) AS cum_sum_total_distance_nm_under_10,
-			ROUND(total_distance_nm_btwn_10_12, 2) AS total_distance_nm_btwn_10_12,
-			ROUND(total_distance_nm_btwn_12_15, 2) AS total_distance_nm_btwn_12_15,
-			ROUND(total_distance_nm_over_15, 2)    AS total_distance_nm_over_15,
-			ROUND(avg_speed_knots, 2)              AS avg_speed_knots,
-			ship_categories_list,
-			mmsi_list,
-			name_of_ships,
-      max_timestamp ,
-      min_timestamp ,
-      include_exclude_category AS exclude_category,
-      vsr_category
-		FROM (
-			SELECT
-				*,
-				(SAFE_DIVIDE(total_distance_nm_under_10 , total_distance_nm)) * 100 AS coop_score,
-        EXTRACT(YEAR FROM date) AS year,
-			FROM (
-				SELECT
-					operator,
-					operator_code,
-					date,
-          vsr_region,
-          vsr_category,
-					COUNT(DISTINCT (mmsi)) AS daily_ship_count,
-					SUM(total_distance_nm) AS total_distance_nm,
-					SUM(total_distance_nm_under_10) AS total_distance_nm_under_10,
-					SUM(total_distance_nm_btwn_10_12) AS total_distance_nm_btwn_10_12,
-					SUM(total_distance_nm_btwn_12_15) AS total_distance_nm_btwn_12_15,
-					SUM(total_distance_nm_over_15) AS total_distance_nm_over_15,
-					SAFE_DIVIDE(SUM(avg_speed_knots) , COUNT(day_count)) AS avg_speed_knots,
-          MAX( max_timestamp ) AS max_timestamp ,
-          MIN( min_timestamp ) AS min_timestamp ,
-					STRING_AGG(DISTINCT(CAST(mmsi AS STRING)), ', ') AS mmsi_list,
-					STRING_AGG(DISTINCT (shiptype), ', ') AS ship_types,
-					STRING_AGG(DISTINCT (name_of_ship), ', ') AS name_of_ships,
-					STRING_AGG(DISTINCT (ship_category), ', ') AS ship_categories_list,
-					CASE WHEN COUNT(DISTINCT (ship_category)) > 1 THEN
-						'multi-category'
-					WHEN COUNT(DISTINCT (ship_category)) = 1 THEN
-						STRING_AGG(DISTINCT (ship_category))
-					END AS operator_ship_categories,
-          CASE WHEN
-          COUNT(DISTINCT (exclude_category)) = 1
-          AND
-          STRING_AGG(DISTINCT(CAST(exclude_category AS STRING)), '') LIKE '%0%'
-          THEN
-						0
-          WHEN
-          COUNT(DISTINCT (exclude_category)) > 1
-          AND STRING_AGG(DISTINCT(CAST(exclude_category AS STRING)), '') LIKE '%01%'
-          THEN
-						0
-          WHEN
-          COUNT(DISTINCT (exclude_category)) > 1
-          AND STRING_AGG(DISTINCT(CAST(exclude_category AS STRING)), '') LIKE '%10%'
-          THEN
-						0
-          WHEN
-          COUNT(DISTINCT (exclude_category)) = 1
-          AND
-          STRING_AGG(DISTINCT(CAST(exclude_category AS STRING)), '') LIKE '%1%'
-          THEN
-            1
-					END AS include_exclude_category
-          FROM
-					`whalesafe_v3.ship_stats_daily`
-				GROUP BY
-					operator,
-					operator_code,
-					date,
-          vsr_region,
-          vsr_category
+CREATE TABLE IF NOT EXISTS `whalsafe_v3.operator_stats_daily` CLUSTER BY operator, 
+operator_ship_categories, 
+date, 
+coop_score_daily AS 
+SELECT 
+  operator, 
+  operator_code, 
+  operator_ship_categories, 
+  date, 
+  vsr_region, 
+  coop_score_daily, 
+  day_grade, 
+  rolling_coop_score, 
+  rolling_day_grade, 
+  daily_ship_count, 
+  total_distance_nm, 
+  cum_sum_total_distance_nm, 
+  total_distance_nm_under_10, 
+  cum_sum_total_distance_nm_under_10, 
+  total_distance_nm_btwn_10_12, 
+  total_distance_nm_btwn_12_15, 
+  total_distance_nm_over_15, 
+  avg_speed_knots, 
+  ship_categories_list, 
+  mmsi_list, 
+  name_of_ships, 
+  max_timestamp, 
+  min_timestamp, 
+  exclude_category, 
+  vsr_category 
+FROM 
+  (
+    SELECT 
+      CASE WHEN rolling_coop_score >= 99 THEN 'A+' WHEN rolling_coop_score < 99 
+      AND rolling_coop_score >= 80 THEN 'A' WHEN rolling_coop_score < 80 
+      AND rolling_coop_score >= 60 THEN 'B' WHEN rolling_coop_score < 60 
+      AND rolling_coop_score >= 40 THEN 'C' WHEN rolling_coop_score < 40 
+      AND rolling_coop_score >= 20 THEN 'D' ELSE 'F' END AS rolling_day_grade, 
+      * 
+    FROM 
+      (
+        SELECT 
+          operator, 
+          operator_code, 
+          operator_ship_categories, 
+          date, 
+          vsr_region, 
+          ROUND(coop_score, 2) AS coop_score_daily, 
+          CASE WHEN coop_score >= 99 THEN 'A+' WHEN coop_score < 99 
+          AND coop_score >= 80 THEN 'A' WHEN coop_score < 80 
+          AND coop_score >= 60 THEN 'B' WHEN coop_score < 60 
+          AND coop_score >= 40 THEN 'C' WHEN coop_score < 40 
+          AND coop_score >= 20 THEN 'D' ELSE 'F' END AS day_grade, 
+          ROUND(
+            (
+              SAFE_DIVIDE(
+                (
+                  SUM(total_distance_nm_under_10) OVER (
+                    PARTITION BY operator, 
+                    vsr_region, 
+                    year 
+                    ORDER BY 
+                      date, 
+                      year
+                  )
+                ), 
+                (
+                  SUM(total_distance_nm) OVER (
+                    PARTITION BY operator, 
+                    vsr_region, 
+                    year 
+                    ORDER BY 
+                      date, 
+                      year
+                  )
+                )
+              )* 100
+            ), 
+            2
+          ) AS rolling_coop_score, 
+          daily_ship_count, 
+          ROUND(total_distance_nm, 2) AS total_distance_nm, 
+          ROUND(
+            SUM(total_distance_nm) OVER (
+              PARTITION BY operator, 
+              vsr_region, 
+              year 
+              ORDER BY 
+                date, 
+                year
+            ), 
+            2
+          ) AS cum_sum_total_distance_nm, 
+          ROUND(total_distance_nm_under_10, 2) AS total_distance_nm_under_10, 
+          ROUND(
+            SUM(total_distance_nm_under_10) OVER (
+              PARTITION BY operator, 
+              vsr_region, 
+              year 
+              ORDER BY 
+                date, 
+                year
+            ), 
+            2
+          ) AS cum_sum_total_distance_nm_under_10, 
+          ROUND(total_distance_nm_btwn_10_12, 2) AS total_distance_nm_btwn_10_12, 
+          ROUND(total_distance_nm_btwn_12_15, 2) AS total_distance_nm_btwn_12_15, 
+          ROUND(total_distance_nm_over_15, 2) AS total_distance_nm_over_15, 
+          ROUND(avg_speed_knots, 2) AS avg_speed_knots, 
+          ship_categories_list, 
+          mmsi_list, 
+          name_of_ships, 
+          max_timestamp, 
+          min_timestamp, 
+          include_exclude_category AS exclude_category, 
+          vsr_category 
+        FROM 
+          (
+            SELECT 
+              *, 
+              (
+                SAFE_DIVIDE(
+                  total_distance_nm_under_10, total_distance_nm
+                )
+              ) * 100 AS coop_score, 
+              EXTRACT(
+                YEAR 
+                FROM 
+                  date
+              ) AS year, 
+            FROM 
+              (
+                SELECT 
+                  operator, 
+                  operator_code, 
+                  date, 
+                  vsr_region, 
+                  vsr_category, 
+                  COUNT(
+                    DISTINCT (mmsi)
+                  ) AS daily_ship_count, 
+                  SUM(total_distance_nm) AS total_distance_nm, 
+                  SUM(total_distance_nm_under_10) AS total_distance_nm_under_10, 
+                  SUM(total_distance_nm_btwn_10_12) AS total_distance_nm_btwn_10_12, 
+                  SUM(total_distance_nm_btwn_12_15) AS total_distance_nm_btwn_12_15, 
+                  SUM(total_distance_nm_over_15) AS total_distance_nm_over_15, 
+                  SAFE_DIVIDE(
+                    SUM(avg_speed_knots), 
+                    COUNT(day_count)
+                  ) AS avg_speed_knots, 
+                  MAX(max_timestamp) AS max_timestamp, 
+                  MIN(min_timestamp) AS min_timestamp, 
+                  STRING_AGG(
+                    DISTINCT(
+                      CAST(mmsi AS STRING)
+                    ), 
+                    ', '
+                  ) AS mmsi_list, 
+                  STRING_AGG(
+                    DISTINCT (shiptype), 
+                    ', '
+                  ) AS ship_types, 
+                  STRING_AGG(
+                    DISTINCT (name_of_ship), 
+                    ', '
+                  ) AS name_of_ships, 
+                  STRING_AGG(
+                    DISTINCT (ship_category), 
+                    ', '
+                  ) AS ship_categories_list, 
+                  CASE WHEN COUNT(
+                    DISTINCT (ship_category)
+                  ) > 1 THEN 'multi-category' WHEN COUNT(
+                    DISTINCT (ship_category)
+                  ) = 1 THEN STRING_AGG(
+                    DISTINCT (ship_category)
+                  ) END AS operator_ship_categories, 
+                  CASE WHEN COUNT(
+                    DISTINCT (exclude_category)
+                  ) = 1 
+                  AND STRING_AGG(
+                    DISTINCT(
+                      CAST(exclude_category AS STRING)
+                    ), 
+                    ''
+                  ) LIKE '%0%' THEN 0 WHEN COUNT(
+                    DISTINCT (exclude_category)
+                  ) > 1 
+                  AND STRING_AGG(
+                    DISTINCT(
+                      CAST(exclude_category AS STRING)
+                    ), 
+                    ''
+                  ) LIKE '%01%' THEN 0 WHEN COUNT(
+                    DISTINCT (exclude_category)
+                  ) > 1 
+                  AND STRING_AGG(
+                    DISTINCT(
+                      CAST(exclude_category AS STRING)
+                    ), 
+                    ''
+                  ) LIKE '%10%' THEN 0 WHEN COUNT(
+                    DISTINCT (exclude_category)
+                  ) = 1 
+                  AND STRING_AGG(
+                    DISTINCT(
+                      CAST(exclude_category AS STRING)
+                    ), 
+                    ''
+                  ) LIKE '%1%' THEN 1 END AS include_exclude_category 
+                FROM 
+                  `whalsafe_v3.ship_stats_daily` 
+                GROUP BY 
+                  operator, 
+                  operator_code, 
+                  date, 
+                  vsr_region, 
+                  vsr_category
+              )
           )
-          )
-          )
-          )
-          ;
-
+      )
+  );
 -- # -- Step 2: Create a timestamp log to track newest timestamps in stats data.
-CREATE TABLE IF NOT EXISTS `whalesafe_v3.stats_log` (
-      newest_timestamp TIMESTAMP,
-      newest_date DATE,
-			date_accessed TIMESTAMP,
-			table_name STRING);
-
+CREATE TABLE IF NOT EXISTS `whalsafe_v3.stats_log` (
+  newest_timestamp TIMESTAMP, newest_date DATE, 
+  date_accessed TIMESTAMP, table_name STRING
+);
 -- -- # -- Step 3: Insert newest timestamp into log
-INSERT INTO `whalesafe_v3.stats_log`
-SELECT
-	(
-		SELECT
-			MAX(max_timestamp)
-		FROM
-			`whalesafe_v3.operator_stats_daily`
-		LIMIT 1) AS newest_timestamp,
-    (
-		SELECT
-			(MAX(date))
-		FROM
-			`whalesafe_v3.operator_stats_daily`
-		LIMIT 1) AS newest_date,
-	CURRENT_TIMESTAMP() AS date_accessed,
-	'operator_stats_daily' AS table_name;
+INSERT INTO `whalsafe_v3.stats_log` 
+SELECT 
+  (
+    SELECT 
+      MAX(max_timestamp) 
+    FROM 
+      `whalsafe_v3.operator_stats_daily` 
+    LIMIT 
+      1
+  ) AS newest_timestamp, 
+  (
+    SELECT 
+      (
+        MAX(date)
+      ) 
+    FROM 
+      `whalsafe_v3.operator_stats_daily` 
+    LIMIT 
+      1
+  ) AS newest_date, 
+  CURRENT_TIMESTAMP() AS date_accessed, 
+  'operator_stats_daily' AS table_name;

--- a/sql_v3_scheduled-on-BigQuery/update_whalesafe_v3_operator_stats_monthly.sql
+++ b/sql_v3_scheduled-on-BigQuery/update_whalesafe_v3_operator_stats_monthly.sql
@@ -1,222 +1,280 @@
--- # -- # Updating `whalesafe_v3.operator_stats_monthly` -- # --
+-- # -- # Updating `whalsafe_v3.operator_stats_monthly` -- # --
 -- # Benioff Ocean Initiative: 2020-07-30
 -- # -- Needs `ship_stats_daily` to run.
-
 -- # -- Step 0: Drop existing `operator_stats_monthly` table.
-DROP TABLE IF EXISTS `whalesafe_v3.operator_stats_monthly`;
-
+DROP 
+  TABLE IF EXISTS `whalsafe_v3.operator_stats_monthly`;
 -- # -- Step 1:Create Updated operator_stats_monthly table.
-CREATE TABLE IF NOT EXISTS `whalesafe_v3.operator_stats_monthly` CLUSTER BY
-		operator,
-		operator_ship_categories,
-		month,
-		coop_score_monthly AS
-SELECT
-operator,
-operator_code,
-operator_ship_categories,
-vsr_region,
-month,
-year,
-coop_score_monthly,
-cooperation_score_monthly,
-month_grade,
-rolling_coop_score,
-rolling_month_grade,
-month_ship_count,
-total_distance_nm,
-cum_sum_total_distance_nm,
-total_distance_nm_under_10,
-cum_sum_total_distance_nm_under_10,
-total_distance_nm_btwn_10_12,
-total_distance_nm_btwn_12_15,
-total_distance_nm_over_15,
-avg_speed_knots,
-ship_categories_list,
-mmsi_list,
-name_of_ships,
-min_timestamp,
-max_timestamp,
-exclude_category
-FROM(
-    SELECT
-    CASE WHEN rolling_coop_score >= 99 THEN
-				'A+'
-			WHEN rolling_coop_score < 99
-				AND rolling_coop_score >= 80 THEN
-				'A'
-			WHEN rolling_coop_score < 80
-				AND rolling_coop_score >= 60 THEN
-				'B'
-			WHEN rolling_coop_score < 60
-				AND rolling_coop_score >= 40 THEN
-				'C'
-			WHEN rolling_coop_score < 40
-				AND rolling_coop_score >= 20 THEN
-				'D'
-			ELSE
-				'F'
-			END AS rolling_month_grade,
-    *
-    FROM(
-    SELECT
-			operator,
-			operator_code,
-      operator_ship_categories,
-      vsr_region,
-			month,
-			year,
-			ROUND(
-			coop_score, 2) AS coop_score_monthly ,
-			CONCAT(
-			ROUND(coop_score, 2), '%', ' ', '(', month_name, ' ', year, ')') AS cooperation_score_monthly,
-			CASE WHEN coop_score >= 99 THEN
-				'A+'
-			WHEN coop_score < 99
-				AND coop_score >= 80 THEN
-				'A'
-			WHEN coop_score < 80
-				AND coop_score >= 60 THEN
-				'B'
-			WHEN coop_score < 60
-				AND coop_score >= 40 THEN
-				'C'
-			WHEN coop_score < 40
-				AND coop_score >= 20 THEN
-				'D'
-			ELSE
-				'F'
-			END AS month_grade,
-			ROUND(((ROUND(SUM(total_distance_nm_under_10) OVER (PARTITION BY operator, vsr_region, year ORDER BY operator, month, year ROWS BETWEEN 12 PRECEDING AND CURRENT ROW), 2) / ROUND(SUM(total_distance_nm) OVER (PARTITION BY operator, vsr_region, year ORDER BY operator, month, year ROWS BETWEEN 12 PRECEDING AND CURRENT ROW), 2))* 100),2) AS rolling_coop_score,
-			month_ship_count,
-			ROUND(total_distance_nm, 2) AS total_distance_nm,
-      ROUND(SUM(total_distance_nm) OVER (PARTITION BY operator, vsr_region, year ORDER BY operator, month, year ROWS BETWEEN 12 PRECEDING AND CURRENT ROW), 2) AS cum_sum_total_distance_nm,
-			ROUND(total_distance_nm_under_10, 2) AS total_distance_nm_under_10,
-      ROUND(SUM(total_distance_nm_under_10) OVER (PARTITION BY operator, vsr_region, year ORDER BY operator, month, year ROWS BETWEEN 12 PRECEDING AND CURRENT ROW), 2) AS cum_sum_total_distance_nm_under_10,
-			ROUND(total_distance_nm_btwn_10_12, 2) AS total_distance_nm_btwn_10_12,
-			ROUND(total_distance_nm_btwn_12_15, 2) AS total_distance_nm_btwn_12_15,
-			ROUND(total_distance_nm_over_15, 2) AS total_distance_nm_over_15,
-			ROUND(avg_speed_knots, 2) AS avg_speed_knots,
-			ship_categories_list,
-			mmsi_list,
-			name_of_ships,
-      max_timestamp ,
-      min_timestamp ,
-      include_exclude_category AS exclude_category
-		FROM (
-			SELECT
-				*,
-				(total_distance_nm_under_10 / total_distance_nm) * 100 AS coop_score,
-				CASE
-        WHEN month = 1 THEN
-					'jan'
-				WHEN month = 2 THEN
-					'feb'
-				WHEN month = 3 THEN
-					'mar'
-				WHEN month = 4 THEN
-					'apr'
-				WHEN month = 5 THEN
-					'may'
-				WHEN month = 6 THEN
-					'jun'
-				WHEN month = 7 THEN
-					'jul'
-				WHEN month = 8 THEN
-					'aug'
-				WHEN month = 9 THEN
-					'sep'
-				WHEN month = 10 THEN
-					'oct'
-				WHEN month = 11 THEN
-					'nov'
-				WHEN month = 12 THEN
-					'dec'
-				END AS month_name
-			FROM (
-				SELECT
-					operator,
-					operator_code,
-          vsr_region,
-					EXTRACT(month FROM date) AS month,
-					EXTRACT(year FROM date) AS year,
-					COUNT(DISTINCT (mmsi)) AS month_ship_count,
-					SUM(total_distance_nm) AS total_distance_nm,
-					SUM(total_distance_nm_under_10) AS total_distance_nm_under_10,
-					SUM(total_distance_nm_btwn_10_12) AS total_distance_nm_btwn_10_12,
-					SUM(total_distance_nm_btwn_12_15) AS total_distance_nm_btwn_12_15,
-					SUM(total_distance_nm_over_15) AS total_distance_nm_over_15,
-					(SUM(avg_speed_knots)/COUNT(day_count)) AS avg_speed_knots,
-          MAX( max_timestamp ) AS max_timestamp ,
-          MIN( min_timestamp ) AS min_timestamp ,
-					STRING_AGG(DISTINCT(CAST(mmsi AS STRING)), ', ') AS mmsi_list,
-					STRING_AGG(DISTINCT (shiptype), ', ') AS ship_types,
-					STRING_AGG(DISTINCT (name_of_ship), ', ') AS name_of_ships,
-					STRING_AGG(DISTINCT (ship_category), ', ') AS ship_categories_list,
-					CASE WHEN COUNT(DISTINCT (ship_category)) > 1 THEN
-						'multi-category'
-					WHEN COUNT(DISTINCT (ship_category)) = 1 THEN
-						STRING_AGG(DISTINCT (ship_category))
-					END AS operator_ship_categories,
-          CASE WHEN
-          COUNT(DISTINCT (exclude_category)) = 1
-          AND
-          STRING_AGG(DISTINCT(CAST(exclude_category AS STRING)), '') LIKE '%0%'
-          THEN
-						0
-          WHEN
-          COUNT(DISTINCT (exclude_category)) > 1
-          AND STRING_AGG(DISTINCT(CAST(exclude_category AS STRING)), '') LIKE '%01%'
-          THEN
-						0
-          WHEN
-          COUNT(DISTINCT (exclude_category)) > 1
-          AND STRING_AGG(DISTINCT(CAST(exclude_category AS STRING)), '') LIKE '%10%'
-          THEN
-						0
-          WHEN
-          COUNT(DISTINCT (exclude_category)) = 1
-          AND
-          STRING_AGG(DISTINCT(CAST(exclude_category AS STRING)), '') LIKE '%1%'
-          THEN
-            1
-					END AS include_exclude_category
-          FROM
-					`whalesafe_v3.ship_stats_daily`
-          WHERE vsr_category NOT LIKE '%off%'
-				GROUP BY
-					operator,
-					operator_code,
-          vsr_region,
-					month,
-					year
+CREATE TABLE IF NOT EXISTS `whalsafe_v3.operator_stats_monthly` CLUSTER BY operator, 
+operator_ship_categories, 
+month, 
+coop_score_monthly AS 
+SELECT 
+  operator, 
+  operator_code, 
+  operator_ship_categories, 
+  vsr_region, 
+  month, 
+  year, 
+  coop_score_monthly, 
+  cooperation_score_monthly, 
+  month_grade, 
+  rolling_coop_score, 
+  rolling_month_grade, 
+  month_ship_count, 
+  total_distance_nm, 
+  cum_sum_total_distance_nm, 
+  total_distance_nm_under_10, 
+  cum_sum_total_distance_nm_under_10, 
+  total_distance_nm_btwn_10_12, 
+  total_distance_nm_btwn_12_15, 
+  total_distance_nm_over_15, 
+  avg_speed_knots, 
+  ship_categories_list, 
+  mmsi_list, 
+  name_of_ships, 
+  min_timestamp, 
+  max_timestamp, 
+  exclude_category 
+FROM 
+  (
+    SELECT 
+      CASE WHEN rolling_coop_score >= 99 THEN 'A+' WHEN rolling_coop_score < 99 
+      AND rolling_coop_score >= 80 THEN 'A' WHEN rolling_coop_score < 80 
+      AND rolling_coop_score >= 60 THEN 'B' WHEN rolling_coop_score < 60 
+      AND rolling_coop_score >= 40 THEN 'C' WHEN rolling_coop_score < 40 
+      AND rolling_coop_score >= 20 THEN 'D' ELSE 'F' END AS rolling_month_grade, 
+      * 
+    FROM 
+      (
+        SELECT 
+          operator, 
+          operator_code, 
+          operator_ship_categories, 
+          vsr_region, 
+          month, 
+          year, 
+          ROUND(coop_score, 2) AS coop_score_monthly, 
+          CONCAT(
+            ROUND(coop_score, 2), 
+            '%', 
+            ' ', 
+            '(', 
+            month_name, 
+            ' ', 
+            year, 
+            ')'
+          ) AS cooperation_score_monthly, 
+          CASE WHEN coop_score >= 99 THEN 'A+' WHEN coop_score < 99 
+          AND coop_score >= 80 THEN 'A' WHEN coop_score < 80 
+          AND coop_score >= 60 THEN 'B' WHEN coop_score < 60 
+          AND coop_score >= 40 THEN 'C' WHEN coop_score < 40 
+          AND coop_score >= 20 THEN 'D' ELSE 'F' END AS month_grade, 
+          ROUND(
+            (
+              (
+                ROUND(
+                  SUM(total_distance_nm_under_10) OVER (
+                    PARTITION BY operator, 
+                    vsr_region, 
+                    year 
+                    ORDER BY 
+                      operator, 
+                      month, 
+                      year ROWS BETWEEN 12 PRECEDING 
+                      AND CURRENT ROW
+                  ), 
+                  2
+                ) / ROUND(
+                  SUM(total_distance_nm) OVER (
+                    PARTITION BY operator, 
+                    vsr_region, 
+                    year 
+                    ORDER BY 
+                      operator, 
+                      month, 
+                      year ROWS BETWEEN 12 PRECEDING 
+                      AND CURRENT ROW
+                  ), 
+                  2
+                )
+              )* 100
+            ), 
+            2
+          ) AS rolling_coop_score, 
+          month_ship_count, 
+          ROUND(total_distance_nm, 2) AS total_distance_nm, 
+          ROUND(
+            SUM(total_distance_nm) OVER (
+              PARTITION BY operator, 
+              vsr_region, 
+              year 
+              ORDER BY 
+                operator, 
+                month, 
+                year ROWS BETWEEN 12 PRECEDING 
+                AND CURRENT ROW
+            ), 
+            2
+          ) AS cum_sum_total_distance_nm, 
+          ROUND(total_distance_nm_under_10, 2) AS total_distance_nm_under_10, 
+          ROUND(
+            SUM(total_distance_nm_under_10) OVER (
+              PARTITION BY operator, 
+              vsr_region, 
+              year 
+              ORDER BY 
+                operator, 
+                month, 
+                year ROWS BETWEEN 12 PRECEDING 
+                AND CURRENT ROW
+            ), 
+            2
+          ) AS cum_sum_total_distance_nm_under_10, 
+          ROUND(total_distance_nm_btwn_10_12, 2) AS total_distance_nm_btwn_10_12, 
+          ROUND(total_distance_nm_btwn_12_15, 2) AS total_distance_nm_btwn_12_15, 
+          ROUND(total_distance_nm_over_15, 2) AS total_distance_nm_over_15, 
+          ROUND(avg_speed_knots, 2) AS avg_speed_knots, 
+          ship_categories_list, 
+          mmsi_list, 
+          name_of_ships, 
+          max_timestamp, 
+          min_timestamp, 
+          include_exclude_category AS exclude_category 
+        FROM 
+          (
+            SELECT 
+              *, 
+              (
+                total_distance_nm_under_10 / total_distance_nm
+              ) * 100 AS coop_score, 
+              CASE WHEN month = 1 THEN 'jan' WHEN month = 2 THEN 'feb' WHEN month = 3 THEN 'mar' WHEN month = 4 THEN 'apr' WHEN month = 5 THEN 'may' WHEN month = 6 THEN 'jun' WHEN month = 7 THEN 'jul' WHEN month = 8 THEN 'aug' WHEN month = 9 THEN 'sep' WHEN month = 10 THEN 'oct' WHEN month = 11 THEN 'nov' WHEN month = 12 THEN 'dec' END AS month_name 
+            FROM 
+              (
+                SELECT 
+                  operator, 
+                  operator_code, 
+                  vsr_region, 
+                  EXTRACT(
+                    month 
+                    FROM 
+                      date
+                  ) AS month, 
+                  EXTRACT(
+                    year 
+                    FROM 
+                      date
+                  ) AS year, 
+                  COUNT(
+                    DISTINCT (mmsi)
+                  ) AS month_ship_count, 
+                  SUM(total_distance_nm) AS total_distance_nm, 
+                  SUM(total_distance_nm_under_10) AS total_distance_nm_under_10, 
+                  SUM(total_distance_nm_btwn_10_12) AS total_distance_nm_btwn_10_12, 
+                  SUM(total_distance_nm_btwn_12_15) AS total_distance_nm_btwn_12_15, 
+                  SUM(total_distance_nm_over_15) AS total_distance_nm_over_15, 
+                  (
+                    SUM(avg_speed_knots)/ COUNT(day_count)
+                  ) AS avg_speed_knots, 
+                  MAX(max_timestamp) AS max_timestamp, 
+                  MIN(min_timestamp) AS min_timestamp, 
+                  STRING_AGG(
+                    DISTINCT(
+                      CAST(mmsi AS STRING)
+                    ), 
+                    ', '
+                  ) AS mmsi_list, 
+                  STRING_AGG(
+                    DISTINCT (shiptype), 
+                    ', '
+                  ) AS ship_types, 
+                  STRING_AGG(
+                    DISTINCT (name_of_ship), 
+                    ', '
+                  ) AS name_of_ships, 
+                  STRING_AGG(
+                    DISTINCT (ship_category), 
+                    ', '
+                  ) AS ship_categories_list, 
+                  CASE WHEN COUNT(
+                    DISTINCT (ship_category)
+                  ) > 1 THEN 'multi-category' WHEN COUNT(
+                    DISTINCT (ship_category)
+                  ) = 1 THEN STRING_AGG(
+                    DISTINCT (ship_category)
+                  ) END AS operator_ship_categories, 
+                  CASE WHEN COUNT(
+                    DISTINCT (exclude_category)
+                  ) = 1 
+                  AND STRING_AGG(
+                    DISTINCT(
+                      CAST(exclude_category AS STRING)
+                    ), 
+                    ''
+                  ) LIKE '%0%' THEN 0 WHEN COUNT(
+                    DISTINCT (exclude_category)
+                  ) > 1 
+                  AND STRING_AGG(
+                    DISTINCT(
+                      CAST(exclude_category AS STRING)
+                    ), 
+                    ''
+                  ) LIKE '%01%' THEN 0 WHEN COUNT(
+                    DISTINCT (exclude_category)
+                  ) > 1 
+                  AND STRING_AGG(
+                    DISTINCT(
+                      CAST(exclude_category AS STRING)
+                    ), 
+                    ''
+                  ) LIKE '%10%' THEN 0 WHEN COUNT(
+                    DISTINCT (exclude_category)
+                  ) = 1 
+                  AND STRING_AGG(
+                    DISTINCT(
+                      CAST(exclude_category AS STRING)
+                    ), 
+                    ''
+                  ) LIKE '%1%' THEN 1 END AS include_exclude_category 
+                FROM 
+                  `whalsafe_v3.ship_stats_daily` 
+                WHERE 
+                  vsr_category NOT LIKE '%off%' 
+                GROUP BY 
+                  operator, 
+                  operator_code, 
+                  vsr_region, 
+                  month, 
+                  year
+              )
           )
-          )
-          )
-          )
-          ;
-
+      )
+  );
 -- # -- Step 2: Create a timestamp log to track newest timestamps in stats data.
-CREATE TABLE IF NOT EXISTS `whalesafe_v3.stats_log` (
-      newest_timestamp TIMESTAMP,
-      newest_date DATE,
-			date_accessed TIMESTAMP,
-			table_name STRING);
-
+CREATE TABLE IF NOT EXISTS `whalsafe_v3.stats_log` (
+  newest_timestamp TIMESTAMP, newest_date DATE, 
+  date_accessed TIMESTAMP, table_name STRING
+);
 -- # -- Step 3: Insert newest timestamp into log
-INSERT INTO `whalesafe_v3.stats_log`
-SELECT
-	(
-		SELECT
-			MAX(max_timestamp)
-		FROM
-			`whalesafe_v3.operator_stats_monthly`
-		LIMIT 1) AS newest_timestamp,
-    (
-		SELECT
-			DATE(MAX(max_timestamp))
-		FROM
-			`whalesafe_v3.operator_stats_monthly`
-		LIMIT 1) AS newest_date,
-	CURRENT_TIMESTAMP() AS date_accessed,
-	'operator_stats_monthly' AS table_name;
+INSERT INTO `whalsafe_v3.stats_log` 
+SELECT 
+  (
+    SELECT 
+      MAX(max_timestamp) 
+    FROM 
+      `whalsafe_v3.operator_stats_monthly` 
+    LIMIT 
+      1
+  ) AS newest_timestamp, 
+  (
+    SELECT 
+      DATE(
+        MAX(max_timestamp)
+      ) 
+    FROM 
+      `whalsafe_v3.operator_stats_monthly` 
+    LIMIT 
+      1
+  ) AS newest_date, 
+  CURRENT_TIMESTAMP() AS date_accessed, 
+  'operator_stats_monthly' AS table_name;

--- a/sql_v3_scheduled-on-BigQuery/update_whalesafe_v3_ship_stats_annual.sql
+++ b/sql_v3_scheduled-on-BigQuery/update_whalesafe_v3_ship_stats_annual.sql
@@ -1,115 +1,248 @@
--- # -- # Updating `whalesafe_v3.ship_stats_annual` -- # --
+-- # -- # Updating `whalsafe_v3.ship_stats_annual` -- # --
 -- # Benioff Ocean Initiative: 2020-07-30
 -- # -- Needs `ship_stats_daily` to run.
-
 -- # -- Step 0: Drop existing `ship_stats_annual` table.
-DROP TABLE IF EXISTS `whalesafe_v3.ship_stats_annual`;
-
+DROP 
+  TABLE IF EXISTS `whalsafe_v3.ship_stats_annual`;
 -- # -- Step 1: Create Updated `ship_stats_annual` table.
-CREATE TABLE IF NOT EXISTS `whalesafe_v3.ship_stats_annual`
-CLUSTER BY mmsi, operator, coop_score_annual, vsr_region
-AS
-SELECT
-    mmsi, name_of_ship,
-    operator, operator_code, technical_manager,
-    shiptype, ship_category, vsr_region,
-    year,
-    coop_score_annual,
-    CASE
-    WHEN ((total_distance_nm_under_10 / total_distance_nm) * 100) >= 99 THEN
-					'A+'
-				WHEN ((total_distance_nm_under_10 / total_distance_nm) * 100) < 99
-		AND((total_distance_nm_under_10 / total_distance_nm) * 100) >= 80 THEN
-					'A'
-				WHEN ((total_distance_nm_under_10 / total_distance_nm) * 100) < 80
-		AND((total_distance_nm_under_10 / total_distance_nm) * 100) >= 60 THEN
-					'B'
-				WHEN ((total_distance_nm_under_10 / total_distance_nm) * 100) < 60
-		AND((total_distance_nm_under_10 / total_distance_nm) * 100) >= 40 THEN
-					'C'
-				WHEN ((total_distance_nm_under_10 / total_distance_nm) * 100) < 40
-		AND((total_distance_nm_under_10 / total_distance_nm) * 100) >= 20 THEN
-					'D'
-    ELSE
-      'F'
-    END AS year_grade,
-ROUND((ROUND(SUM(total_distance_nm_under_10) OVER (PARTITION BY mmsi, vsr_region ORDER BY mmsi, year ROWS BETWEEN 12 PRECEDING AND CURRENT ROW), 2) / ROUND(SUM(total_distance_nm) OVER (PARTITION BY mmsi, vsr_region ORDER BY mmsi, year ROWS BETWEEN 12 PRECEDING AND CURRENT ROW), 2)*100),2) AS rolling_coop_score,
-    ROUND(total_distance_nm, 2) AS total_distance_nm,
-    ROUND(SUM(total_distance_nm) OVER (PARTITION BY mmsi, vsr_region ORDER BY mmsi, year ROWS BETWEEN 12 PRECEDING AND CURRENT ROW), 2) AS cum_sum_total_distance_nm,
-    ROUND(total_distance_nm_under_10, 2) AS total_distance_nm_under_10,
-    ROUND(SUM(total_distance_nm_under_10) OVER (PARTITION BY mmsi, vsr_region ORDER BY mmsi, year ROWS BETWEEN 12 PRECEDING AND CURRENT ROW), 2) AS cum_sum_total_distance_nm_under_10,
-    CONCAT(ROUND(((total_distance_nm_under_10 / total_distance_nm)*100), 2), '%') AS percent_distance_under_10,
-    ROUND(total_distance_nm_btwn_10_12, 2) AS total_distance_nm_btwn_10_12,
-    CONCAT(ROUND(((total_distance_nm_btwn_10_12 / total_distance_nm)*100), 2), '%') AS percent_distance_btwn_10_12,
-    ROUND(total_distance_nm_btwn_12_15, 2) AS total_distance_nm_btwn_12_15,
-    CONCAT(ROUND(((total_distance_nm_btwn_12_15 / total_distance_nm)*100), 2), '%') AS percent_distance_btwn_12_15,
-    ROUND(total_distance_nm_over_15, 2) AS total_distance_nm_over_15,
-    CONCAT(ROUND(((total_distance_nm_over_15 / total_distance_nm)*100), 2), '%') AS percent_distance_over_15,
-    ROUND(avg_speed_knots, 2) AS avg_speed_knots,
-    min_timestamp, max_timestamp,
-    gt, day_count, seg_count, exclude_category
-FROM(
-SELECT
-mmsi,
-name_of_ship,
-operator,
-operator_code,
-technical_manager,
-shiptype,
-ship_category,
-vsr_region,
-EXTRACT(YEAR FROM date) AS year,
-ROUND(((SUM(total_distance_nm_under_10) / SUM(total_distance_nm))*100), 2) AS coop_score_annual,
-SUM(total_distance_nm) AS total_distance_nm ,
-SUM(total_distance_nm_under_10) AS total_distance_nm_under_10 ,
-SUM(total_distance_nm_btwn_10_12) AS total_distance_nm_btwn_10_12 ,
-SUM(total_distance_nm_btwn_12_15) AS total_distance_nm_btwn_12_15 ,
-SUM(total_distance_nm_over_15) AS total_distance_nm_over_15 ,
-AVG( avg_speed_knots ) AS avg_speed_knots,
-MIN(min_timestamp) AS min_timestamp ,
-MAX(max_timestamp) AS max_timestamp ,
-gt,
-SUM(day_count) AS day_count ,
-SUM(seg_count) AS seg_count ,
-exclude_category
-FROM `whalesafe_v3.ship_stats_daily`
-WHERE vsr_category NOT LIKE '%off%'
-GROUP BY
-mmsi,
-name_of_ship,
-operator,
-operator_code,
-technical_manager,
-shiptype,
-ship_category,
-vsr_region,
-year,
-gt,
-exclude_category
-)
-;
-
--- # -- Step 2: Create a timestamp log to track newest timestamps in stats data.
-CREATE TABLE IF NOT EXISTS `whalesafe_v3.stats_log` (
-      newest_timestamp TIMESTAMP,
-      newest_date DATE,
-			date_accessed TIMESTAMP,
-			table_name STRING);
-
--- # -- Step 3: Insert newest timestamp into log
-INSERT INTO `whalesafe_v3.stats_log`
-SELECT
-	(
-		SELECT
-			MAX(max_timestamp)
-		FROM
-			`whalesafe_v3.ship_stats_annual`
-		LIMIT 1) AS newest_timestamp,
+CREATE TABLE IF NOT EXISTS `whalsafe_v3.ship_stats_annual` CLUSTER BY mmsi, 
+operator, 
+coop_score_annual, 
+vsr_region AS 
+SELECT 
+  mmsi, 
+  name_of_ship, 
+  operator, 
+  operator_code, 
+  technical_manager, 
+  shiptype, 
+  ship_category, 
+  vsr_region, 
+  year, 
+  coop_score_annual, 
+  CASE WHEN (
     (
-		SELECT
-			DATE(MAX(max_timestamp))
-		FROM
-			`whalesafe_v3.ship_stats_annual`
-		LIMIT 1) AS newest_date,
-	CURRENT_TIMESTAMP() AS date_accessed,
-	'ship_stats_annual' AS table_name;
+      total_distance_nm_under_10 / total_distance_nm
+    ) * 100
+  ) >= 99 THEN 'A+' WHEN (
+    (
+      total_distance_nm_under_10 / total_distance_nm
+    ) * 100
+  ) < 99 
+  AND(
+    (
+      total_distance_nm_under_10 / total_distance_nm
+    ) * 100
+  ) >= 80 THEN 'A' WHEN (
+    (
+      total_distance_nm_under_10 / total_distance_nm
+    ) * 100
+  ) < 80 
+  AND(
+    (
+      total_distance_nm_under_10 / total_distance_nm
+    ) * 100
+  ) >= 60 THEN 'B' WHEN (
+    (
+      total_distance_nm_under_10 / total_distance_nm
+    ) * 100
+  ) < 60 
+  AND(
+    (
+      total_distance_nm_under_10 / total_distance_nm
+    ) * 100
+  ) >= 40 THEN 'C' WHEN (
+    (
+      total_distance_nm_under_10 / total_distance_nm
+    ) * 100
+  ) < 40 
+  AND(
+    (
+      total_distance_nm_under_10 / total_distance_nm
+    ) * 100
+  ) >= 20 THEN 'D' ELSE 'F' END AS year_grade, 
+  ROUND(
+    (
+      ROUND(
+        SUM(total_distance_nm_under_10) OVER (
+          PARTITION BY mmsi, 
+          vsr_region 
+          ORDER BY 
+            mmsi, 
+            year ROWS BETWEEN 12 PRECEDING 
+            AND CURRENT ROW
+        ), 
+        2
+      ) / ROUND(
+        SUM(total_distance_nm) OVER (
+          PARTITION BY mmsi, 
+          vsr_region 
+          ORDER BY 
+            mmsi, 
+            year ROWS BETWEEN 12 PRECEDING 
+            AND CURRENT ROW
+        ), 
+        2
+      )* 100
+    ), 
+    2
+  ) AS rolling_coop_score, 
+  ROUND(total_distance_nm, 2) AS total_distance_nm, 
+  ROUND(
+    SUM(total_distance_nm) OVER (
+      PARTITION BY mmsi, 
+      vsr_region 
+      ORDER BY 
+        mmsi, 
+        year ROWS BETWEEN 12 PRECEDING 
+        AND CURRENT ROW
+    ), 
+    2
+  ) AS cum_sum_total_distance_nm, 
+  ROUND(total_distance_nm_under_10, 2) AS total_distance_nm_under_10, 
+  ROUND(
+    SUM(total_distance_nm_under_10) OVER (
+      PARTITION BY mmsi, 
+      vsr_region 
+      ORDER BY 
+        mmsi, 
+        year ROWS BETWEEN 12 PRECEDING 
+        AND CURRENT ROW
+    ), 
+    2
+  ) AS cum_sum_total_distance_nm_under_10, 
+  CONCAT(
+    ROUND(
+      (
+        (
+          total_distance_nm_under_10 / total_distance_nm
+        )* 100
+      ), 
+      2
+    ), 
+    '%'
+  ) AS percent_distance_under_10, 
+  ROUND(total_distance_nm_btwn_10_12, 2) AS total_distance_nm_btwn_10_12, 
+  CONCAT(
+    ROUND(
+      (
+        (
+          total_distance_nm_btwn_10_12 / total_distance_nm
+        )* 100
+      ), 
+      2
+    ), 
+    '%'
+  ) AS percent_distance_btwn_10_12, 
+  ROUND(total_distance_nm_btwn_12_15, 2) AS total_distance_nm_btwn_12_15, 
+  CONCAT(
+    ROUND(
+      (
+        (
+          total_distance_nm_btwn_12_15 / total_distance_nm
+        )* 100
+      ), 
+      2
+    ), 
+    '%'
+  ) AS percent_distance_btwn_12_15, 
+  ROUND(total_distance_nm_over_15, 2) AS total_distance_nm_over_15, 
+  CONCAT(
+    ROUND(
+      (
+        (
+          total_distance_nm_over_15 / total_distance_nm
+        )* 100
+      ), 
+      2
+    ), 
+    '%'
+  ) AS percent_distance_over_15, 
+  ROUND(avg_speed_knots, 2) AS avg_speed_knots, 
+  min_timestamp, 
+  max_timestamp, 
+  gt, 
+  day_count, 
+  seg_count, 
+  exclude_category 
+FROM 
+  (
+    SELECT 
+      mmsi, 
+      name_of_ship, 
+      operator, 
+      operator_code, 
+      technical_manager, 
+      shiptype, 
+      ship_category, 
+      vsr_region, 
+      EXTRACT(
+        YEAR 
+        FROM 
+          date
+      ) AS year, 
+      ROUND(
+        (
+          (
+            SUM(total_distance_nm_under_10) / SUM(total_distance_nm)
+          )* 100
+        ), 
+        2
+      ) AS coop_score_annual, 
+      SUM(total_distance_nm) AS total_distance_nm, 
+      SUM(total_distance_nm_under_10) AS total_distance_nm_under_10, 
+      SUM(total_distance_nm_btwn_10_12) AS total_distance_nm_btwn_10_12, 
+      SUM(total_distance_nm_btwn_12_15) AS total_distance_nm_btwn_12_15, 
+      SUM(total_distance_nm_over_15) AS total_distance_nm_over_15, 
+      AVG(avg_speed_knots) AS avg_speed_knots, 
+      MIN(min_timestamp) AS min_timestamp, 
+      MAX(max_timestamp) AS max_timestamp, 
+      gt, 
+      SUM(day_count) AS day_count, 
+      SUM(seg_count) AS seg_count, 
+      exclude_category 
+    FROM 
+      `whalsafe_v3.ship_stats_daily` 
+    WHERE 
+      vsr_category NOT LIKE '%off%' 
+    GROUP BY 
+      mmsi, 
+      name_of_ship, 
+      operator, 
+      operator_code, 
+      technical_manager, 
+      shiptype, 
+      ship_category, 
+      vsr_region, 
+      year, 
+      gt, 
+      exclude_category
+  );
+-- # -- Step 2: Create a timestamp log to track newest timestamps in stats data.
+CREATE TABLE IF NOT EXISTS `whalsafe_v3.stats_log` (
+  newest_timestamp TIMESTAMP, newest_date DATE, 
+  date_accessed TIMESTAMP, table_name STRING
+);
+-- # -- Step 3: Insert newest timestamp into log
+INSERT INTO `whalsafe_v3.stats_log` 
+SELECT 
+  (
+    SELECT 
+      MAX(max_timestamp) 
+    FROM 
+      `whalsafe_v3.ship_stats_annual` 
+    LIMIT 
+      1
+  ) AS newest_timestamp, 
+  (
+    SELECT 
+      DATE(
+        MAX(max_timestamp)
+      ) 
+    FROM 
+      `whalsafe_v3.ship_stats_annual` 
+    LIMIT 
+      1
+  ) AS newest_date, 
+  CURRENT_TIMESTAMP() AS date_accessed, 
+  'ship_stats_annual' AS table_name;

--- a/sql_v3_scheduled-on-BigQuery/update_whalesafe_v3_ship_stats_daily.sql
+++ b/sql_v3_scheduled-on-BigQuery/update_whalesafe_v3_ship_stats_daily.sql
@@ -3,273 +3,857 @@
 -- # -- # Run this STATS SCRIPT FIRST.
 -- # -- Step 0: DROP EXISTING `ship_stats_daily` TABLE.
 -- # -- #TODO: write it so it updates instead using temp tables instead of dropping.
-DROP TABLE IF EXISTS `whalesafe_v3.ship_stats_daily`;
-
+DROP 
+  TABLE IF EXISTS `whalesafe_v3.ship_stats_daily`;
 -- # -- Step 1: Create updated ship_stats_daily table.
-CREATE TABLE IF NOT EXISTS `whalesafe_v3.ship_stats_daily`
-CLUSTER BY mmsi, operator, coop_score_daily, rolling_coop_score
-AS
-SELECT
-				mmsi,
-				name_of_ship,
-				operator,
-				operator_code,
-        technical_manager,
-				ship_type AS shiptype,
-				ship_category,
-				date,
-        vsr_region,
-        vsr_category,
-				cooperation_score_daily,
-				ROUND((coop_score_daily), 2) AS coop_score_daily,
-        CASE WHEN (
-			coop_score_daily) >= 99 THEN
-				'A+'
-			WHEN (
-				coop_score_daily) < 99
-				AND(
-					coop_score_daily) >= 80 THEN
-				'A'
-			WHEN (
-				coop_score_daily) < 80
-				AND(
-					coop_score_daily) >= 60 THEN
-				'B'
-			WHEN (
-				coop_score_daily) < 60
-				AND(
-					coop_score_daily) >= 40 THEN
-				'C'
-			WHEN (
-				coop_score_daily) < 40
-				AND(
-					coop_score_daily) >= 20 THEN
-				'D'
-			ELSE
-				'F'
-			END AS coop_grade_daily,
-        ROUND((SAFE_DIVIDE(cum_sum_total_distance_nm_under_10 , cum_sum_total_distance_nm) * 100), 2) AS rolling_coop_score,
-				CASE WHEN (ROUND((SAFE_DIVIDE(cum_sum_total_distance_nm_under_10 , cum_sum_total_distance_nm) * 100), 2)) >= 99 THEN
-					'A+'
-				WHEN (ROUND((SAFE_DIVIDE(cum_sum_total_distance_nm_under_10 , cum_sum_total_distance_nm) * 100), 2)) < 99
-					AND(ROUND((SAFE_DIVIDE(cum_sum_total_distance_nm_under_10 , cum_sum_total_distance_nm) * 100), 2)) >= 80 THEN
-					'A'
-				WHEN (ROUND((SAFE_DIVIDE(cum_sum_total_distance_nm_under_10 , cum_sum_total_distance_nm) * 100), 2)) < 80
-					AND(ROUND((SAFE_DIVIDE(cum_sum_total_distance_nm_under_10 , cum_sum_total_distance_nm) * 100), 2)) >= 60 THEN
-					'B'
-				WHEN (ROUND((SAFE_DIVIDE(cum_sum_total_distance_nm_under_10 , cum_sum_total_distance_nm) * 100), 2)) < 60
-					AND(ROUND((SAFE_DIVIDE(cum_sum_total_distance_nm_under_10 , cum_sum_total_distance_nm) * 100), 2)) >= 40 THEN
-					'C'
-				WHEN (ROUND((SAFE_DIVIDE(cum_sum_total_distance_nm_under_10 , cum_sum_total_distance_nm) * 100), 2)) < 40
-					AND(ROUND((SAFE_DIVIDE(cum_sum_total_distance_nm_under_10 , cum_sum_total_distance_nm) * 100), 2)) >= 20 THEN
-					'D'
-				ELSE
-					'F'
-				END AS rolling_coop_grade,
-				total_distance_nm,
-        cum_sum_total_distance_nm,
-				total_distance_nm_under_10,
-        cum_sum_total_distance_nm_under_10,
-				percent_under_10_knots,
-				total_distance_nm_btwn_10_12,
-				percent_10_12_knots,
-				total_distance_nm_btwn_12_15,
-				percent_12_15_knots,
-				total_distance_nm_over_15,
-				percent_over_15_knots,
-        total_distance_nm_weird,
-        total_distance_nm_wo_filter,
-				avg_speed_knots,
-        min_timestamp,
-        max_timestamp,
-        gt,
-        day_count,
-				seg_count,
-        exclude_category
-			FROM (
-			SELECT
--- 				ROUND(AVG(coop_score_daily) OVER (PARTITION BY mmsi, vsr_region, year ORDER BY mmsi, date, year), 3) AS rolling_coop_score,
-        ROUND(SUM(total_distance_nm_under_10) OVER (PARTITION BY mmsi, vsr_region, year ORDER BY mmsi, date, year),2)
-        AS cum_sum_total_distance_nm_under_10,
-        ROUND(SUM(total_distance_nm) OVER (PARTITION BY mmsi, vsr_region, year ORDER BY mmsi, date, year),2)
-        AS cum_sum_total_distance_nm,
-				*
-			FROM (
-			SELECT
-				mmsi,
-        date,
-        EXTRACT(YEAR FROM date) AS year,
-        vsr_region,
-				name_of_ship,
-				ship_type,
-				IFNULL(ship_category, "OTHER") AS ship_category,
-				operator,
-				operator_code,
-        technical_manager,
-				-- # Get cooperation score
-				CONCAT((ROUND(SAFE_DIVIDE(total_distance_nm_under_10 , total_distance_nm ) * 100, 2)), '%') AS cooperation_score_daily,
-				ROUND((SAFE_DIVIDE(total_distance_nm_under_10 , total_distance_nm ) *100), 2) AS coop_score_daily,
-				-- # Show distances km in each speed bin and Calculate percentages for distances travelled in each speed bin
-				ROUND(total_distance_nm_under_10, 2) total_distance_nm_under_10,
-				CONCAT(ROUND(SAFE_DIVIDE(total_distance_nm_under_10 , total_distance_nm * 100), 1), '%') AS percent_under_10_knots,
-				--
-				ROUND(total_distance_nm_btwn_10_12, 2) total_distance_nm_btwn_10_12,
-				CONCAT(ROUND(SAFE_DIVIDE(total_distance_nm_btwn_10_12 , total_distance_nm * 100), 1), '%') AS percent_10_12_knots,
-				--
-				ROUND(total_distance_nm_btwn_12_15, 2) total_distance_nm_btwn_12_15,
-				CONCAT(ROUND(SAFE_DIVIDE(total_distance_nm_btwn_12_15 , total_distance_nm * 100), 1), '%') AS percent_12_15_knots,
-				--
-				ROUND(total_distance_nm_over_15, 2) total_distance_nm_over_15,
-				CONCAT(ROUND(SAFE_DIVIDE(total_distance_nm_over_15 , total_distance_nm * 100), 1), '%') AS percent_over_15_knots,
-				-- # Show total distance traveled in VSR ZONE
-				ROUND(total_distance_nm, 2) total_distance_nm,
-				day_count,
-				seg_count,
-				-- # Show total distance traveled at speeds > 60 or speeds < 0 in VSR ZONE
-				total_distance_nm_weird,
-        total_distance_nm_wo_filter,
-				-- # Average speed
-				avg_speed_knots,
-				-- # Max and Min speeds in reported, implied, calculated, and lenient speeds
-				max_speed_knots,
-				min_speed_knots,
-				max_implied_speed_knots,
-				min_implied_speed_knots,
-				max_final_calculated_speed_knots,
-				min_final_calculated_speed_knots,
-        max_timestamp,
-        min_timestamp,
-        gt,
-        vsr_category,
-        exclude_category
-			FROM (
-      SELECT
-      DISTINCT(mmsi),
-      date,
-      vsr_region,
-			name_of_ship,
-			ship_type,
-			ship_category,
-			operator,
-			operator_code,
-      technical_manager,
-      gt,
-		  -- # Average speed in knots
-			ROUND(AVG( final_speed_knots ),2) AS avg_speed_knots,
-			-- # Total distance in km where speed <= 10 knots
-			-- # A little weirdness with there being distance travelled at 0 knots...
-			SUM( CASE WHEN final_speed_knots > 0
-				AND final_speed_knots <= 10 THEN
-				(( distance_nm ))
-	ELSE
-		0
-			END) AS total_distance_nm_under_10,
-			-- # Total distance in km where speed > 10 knots and <= 12 knots
-			SUM( CASE WHEN final_speed_knots > 10
-				AND final_speed_knots <= 12 THEN
-				(( distance_nm ))
-	ELSE
-		0
-			END) AS total_distance_nm_btwn_10_12,
-			-- # Total distance in km where speed > 12 knots and <= 15 knots
-			SUM( CASE WHEN final_speed_knots > 12
-				AND final_speed_knots <= 15 THEN
-				(( distance_nm ))
-	ELSE
-		0
-			END) AS total_distance_nm_btwn_12_15,
-			-- # Total distance in km where speed > 15 knots
-			SUM( CASE WHEN final_speed_knots > 15
-				AND final_speed_knots <= 50 THEN
-				(( distance_nm ))
-	ELSE
-		0
-			END) AS total_distance_nm_over_15,
-			-- # Checking for weird speeds from edge cases
-			SUM( CASE WHEN final_speed_knots <= 0
-				AND final_speed_knots > 50
-        OR final_speed_knots IS NULL
-        THEN
-				distance_nm
-			ELSE
-				0
-			END) AS total_distance_nm_weird,
-      SUM( CASE WHEN final_speed_knots > 0
-				AND final_speed_knots <= 50 THEN
-				distance_nm
-			ELSE
-				0
-        END) AS total_distance_nm,
-			(SUM( distance_nm )) AS total_distance_nm_wo_filter,
-			-- # Get distinct day count that a vessel transitted the VSR zone
-			COUNT( num ) AS seg_count,
-			COUNT(DISTINCT (date)) AS day_count,
-			-- # Check max and min speeds for:
-			-- # speed_knots (reported)
-			ROUND(MAX( final_speed_knots ),3) AS max_speed_knots,
-			ROUND(MIN( final_speed_knots ),3) AS min_speed_knots,
-			-- # implied_speed_knots (gfw calculated)
-			ROUND(MAX( implied_speed_knots ),3) AS max_implied_speed_knots,
-			ROUND(MIN( implied_speed_knots ),3) AS min_implied_speed_knots,
-			-- # Final calculated speed (most lenient among the implied_speed_knots (gfw calculated) and calculated_knots (BOI calculated speed))
-			MAX( final_speed_knots ) AS max_final_calculated_speed_knots,
-			MIN( final_speed_knots ) AS min_final_calculated_speed_knots,
-      MAX( timestamp_end ) AS max_timestamp,
-			MIN( timestamp_beg ) AS min_timestamp,
-      vsr_category,
-      exclude_category
-		FROM (
-		SELECT
-			ais.*,
-			cats.*
-		EXCEPT (shiptype)
-FROM (
-SELECT
-	ais.*,
-	ihs.*
-EXCEPT (mmsi, gt)
-FROM
-	`whalesafe_v3.ais_vsr_segments` AS ais
-	LEFT JOIN `whalesafe_v3.ihs_data_all` AS ihs
-  ON ais.mmsi = ihs.mmsi
-WHERE
-	(ais.timestamp) > '1990-01-01'
---   AND touches_coast IS TRUE -- # touches_coast FILTER, UNCOMMENT IF NEEDED
-		AND DATE(ais.timestamp_beg) >= (ihs.start_date)
-		AND DATE(ais.timestamp_end) <= (ihs.end_date)) AS ais
-	LEFT JOIN `whalesafe_v3.shiptype_categories` cats
-  ON TRIM(ais.ship_type) = TRIM(cats.shiptype)
-WHERE
-	ais.gt >= 300
+CREATE TABLE IF NOT EXISTS `whalesafe_v3.ship_stats_daily` CLUSTER BY mmsi, 
+operator, 
+coop_score_daily, 
+rolling_coop_score AS 
+SELECT 
+  mmsi, 
+  name_of_ship, 
+  operator, 
+  operator_code, 
+  technical_manager, 
+  ship_type AS shiptype, 
+  ship_category, 
+  date, 
+  vsr_region, 
+  vsr_category, 
+  cooperation_score_daily, 
+  ROUND(
+    (coop_score_daily), 
+    2
+  ) AS coop_score_daily, 
+  CASE WHEN (coop_score_daily) >= 99 THEN 'A+' WHEN (coop_score_daily) < 99 
+  AND(coop_score_daily) >= 80 THEN 'A' WHEN (coop_score_daily) < 80 
+  AND(coop_score_daily) >= 60 THEN 'B' WHEN (coop_score_daily) < 60 
+  AND(coop_score_daily) >= 40 THEN 'C' WHEN (coop_score_daily) < 40 
+  AND(coop_score_daily) >= 20 THEN 'D' ELSE 'F' END AS coop_grade_daily, 
+  ROUND(
+    (
+      SAFE_DIVIDE(
+        cum_sum_total_distance_nm_under_10, 
+        cum_sum_total_distance_nm
+      ) * 100
+    ), 
+    2
+  ) AS rolling_coop_score, 
+  CASE WHEN (
+    ROUND(
+      (
+        SAFE_DIVIDE(
+          cum_sum_total_distance_nm_under_10, 
+          cum_sum_total_distance_nm
+        ) * 100
+      ), 
+      2
+    )
+  ) >= 99 THEN 'A+' WHEN (
+    ROUND(
+      (
+        SAFE_DIVIDE(
+          cum_sum_total_distance_nm_under_10, 
+          cum_sum_total_distance_nm
+        ) * 100
+      ), 
+      2
+    )
+  ) < 99 
+  AND(
+    ROUND(
+      (
+        SAFE_DIVIDE(
+          cum_sum_total_distance_nm_under_10, 
+          cum_sum_total_distance_nm
+        ) * 100
+      ), 
+      2
+    )
+  ) >= 80 THEN 'A' WHEN (
+    ROUND(
+      (
+        SAFE_DIVIDE(
+          cum_sum_total_distance_nm_under_10, 
+          cum_sum_total_distance_nm
+        ) * 100
+      ), 
+      2
+    )
+  ) < 80 
+  AND(
+    ROUND(
+      (
+        SAFE_DIVIDE(
+          cum_sum_total_distance_nm_under_10, 
+          cum_sum_total_distance_nm
+        ) * 100
+      ), 
+      2
+    )
+  ) >= 60 THEN 'B' WHEN (
+    ROUND(
+      (
+        SAFE_DIVIDE(
+          cum_sum_total_distance_nm_under_10, 
+          cum_sum_total_distance_nm
+        ) * 100
+      ), 
+      2
+    )
+  ) < 60 
+  AND(
+    ROUND(
+      (
+        SAFE_DIVIDE(
+          cum_sum_total_distance_nm_under_10, 
+          cum_sum_total_distance_nm
+        ) * 100
+      ), 
+      2
+    )
+  ) >= 40 THEN 'C' WHEN (
+    ROUND(
+      (
+        SAFE_DIVIDE(
+          cum_sum_total_distance_nm_under_10, 
+          cum_sum_total_distance_nm
+        ) * 100
+      ), 
+      2
+    )
+  ) < 40 
+  AND(
+    ROUND(
+      (
+        SAFE_DIVIDE(
+          cum_sum_total_distance_nm_under_10, 
+          cum_sum_total_distance_nm
+        ) * 100
+      ), 
+      2
+    )
+  ) >= 20 THEN 'D' ELSE 'F' END AS rolling_coop_grade, 
+  total_distance_nm, 
+  cum_sum_total_distance_nm, 
+  total_distance_nm_under_10, 
+  cum_sum_total_distance_nm_under_10, 
+  percent_under_10_knots, 
+  total_distance_nm_btwn_10_12, 
+  percent_10_12_knots, 
+  total_distance_nm_btwn_12_15, 
+  percent_12_15_knots, 
+  total_distance_nm_over_15, 
+  percent_over_15_knots, 
+  total_distance_nm_weird, 
+  total_distance_nm_wo_filter, 
+  avg_speed_knots, 
+  min_timestamp, 
+  max_timestamp, 
+  gt, 
+  day_count, 
+  seg_count, 
+  exclude_category 
+FROM 
+  (
+    SELECT 
+      --         ROUND(AVG(coop_score_daily) OVER (PARTITION BY mmsi, vsr_region, year ORDER BY mmsi, date, year), 3) AS rolling_coop_score,
+      ROUND(
+        SUM(total_distance_nm_under_10) OVER (
+          PARTITION BY mmsi, 
+          vsr_region, 
+          year 
+          ORDER BY 
+            mmsi, 
+            date, 
+            year
+        ), 
+        2
+      ) AS cum_sum_total_distance_nm_under_10, 
+      ROUND(
+        SUM(total_distance_nm) OVER (
+          PARTITION BY mmsi, 
+          vsr_region, 
+          year 
+          ORDER BY 
+            mmsi, 
+            date, 
+            year
+        ), 
+        2
+      ) AS cum_sum_total_distance_nm, 
+      * 
+    FROM 
+      (
+        SELECT 
+          mmsi, 
+          date, 
+          EXTRACT(
+            YEAR 
+            FROM 
+              date
+          ) AS year, 
+          vsr_region, 
+          name_of_ship, 
+          ship_type, 
+          IFNULL(ship_category, "OTHER") AS ship_category, 
+          operator, 
+          operator_code, 
+          technical_manager, 
+          -- # Get cooperation score
+          CONCAT(
+            (
+              ROUND(
+                SAFE_DIVIDE(
+                  total_distance_nm_under_10, total_distance_nm
+                ) * 100, 
+                2
+              )
+            ), 
+            '%'
+          ) AS cooperation_score_daily, 
+          ROUND(
+            (
+              SAFE_DIVIDE(
+                total_distance_nm_under_10, total_distance_nm
+              ) * 100
+            ), 
+            2
+          ) AS coop_score_daily, 
+          -- # Show distances km in each speed bin and Calculate percentages for distances travelled in each speed bin
+          ROUND(total_distance_nm_under_10, 2) total_distance_nm_under_10, 
+          CONCAT(
+            ROUND(
+              SAFE_DIVIDE(
+                total_distance_nm_under_10, total_distance_nm * 100
+              ), 
+              1
+            ), 
+            '%'
+          ) AS percent_under_10_knots, 
+          --
+          ROUND(total_distance_nm_btwn_10_12, 2) total_distance_nm_btwn_10_12, 
+          CONCAT(
+            ROUND(
+              SAFE_DIVIDE(
+                total_distance_nm_btwn_10_12, total_distance_nm * 100
+              ), 
+              1
+            ), 
+            '%'
+          ) AS percent_10_12_knots, 
+          --
+          ROUND(total_distance_nm_btwn_12_15, 2) total_distance_nm_btwn_12_15, 
+          CONCAT(
+            ROUND(
+              SAFE_DIVIDE(
+                total_distance_nm_btwn_12_15, total_distance_nm * 100
+              ), 
+              1
+            ), 
+            '%'
+          ) AS percent_12_15_knots, 
+          --
+          ROUND(total_distance_nm_over_15, 2) total_distance_nm_over_15, 
+          CONCAT(
+            ROUND(
+              SAFE_DIVIDE(
+                total_distance_nm_over_15, total_distance_nm * 100
+              ), 
+              1
+            ), 
+            '%'
+          ) AS percent_over_15_knots, 
+          -- # Show total distance traveled in VSR ZONE
+          ROUND(total_distance_nm, 2) total_distance_nm, 
+          day_count, 
+          seg_count, 
+          -- # Show total distance traveled at speeds > 60 or speeds < 0 in VSR ZONE
+          total_distance_nm_weird, 
+          total_distance_nm_wo_filter, 
+          -- # Average speed
+          avg_speed_knots, 
+          -- # Max and Min speeds in reported, implied, calculated, and lenient speeds
+          max_speed_knots, 
+          min_speed_knots, 
+          max_implied_speed_knots, 
+          min_implied_speed_knots, 
+          max_final_calculated_speed_knots, 
+          min_final_calculated_speed_knots, 
+          max_timestamp, 
+          min_timestamp, 
+          gt, 
+          vsr_category, 
+          exclude_category 
+        FROM 
+          (
+            SELECT 
+              DISTINCT(mmsi), 
+              date, 
+              vsr_region, 
+              name_of_ship, 
+              ship_type, 
+              ship_category, 
+              operator, 
+              operator_code, 
+              technical_manager, 
+              gt, 
+              -- # Average speed in knots
+              ROUND(
+                AVG(final_speed_knots), 
+                2
+              ) AS avg_speed_knots, 
+              -- # Total distance in km where speed <= 10 knots
+              -- # A little weirdness with there being distance travelled at 0 knots...
+              SUM(
+                CASE WHEN final_speed_knots > 0 
+                AND final_speed_knots <= 10 THEN (
+                  (distance_nm)
+                ) ELSE 0 END
+              ) AS total_distance_nm_under_10, 
+              -- # Total distance in km where speed > 10 knots and <= 12 knots
+              SUM(
+                CASE WHEN final_speed_knots > 10 
+                AND final_speed_knots <= 12 THEN (
+                  (distance_nm)
+                ) ELSE 0 END
+              ) AS total_distance_nm_btwn_10_12, 
+              -- # Total distance in km where speed > 12 knots and <= 15 knots
+              SUM(
+                CASE WHEN final_speed_knots > 12 
+                AND final_speed_knots <= 15 THEN (
+                  (distance_nm)
+                ) ELSE 0 END
+              ) AS total_distance_nm_btwn_12_15, 
+              -- # Total distance in km where speed > 15 knots
+              SUM(
+                CASE WHEN final_speed_knots > 15 
+                AND final_speed_knots <= 50 THEN (
+                  (distance_nm)
+                ) ELSE 0 END
+              ) AS total_distance_nm_over_15, 
+              -- # Checking for weird speeds from edge cases
+              SUM(
+                CASE WHEN final_speed_knots <= 0 
+                AND final_speed_knots > 50 
+                OR final_speed_knots IS NULL THEN distance_nm ELSE 0 END
+              ) AS total_distance_nm_weird, 
+              SUM(
+                CASE WHEN final_speed_knots > 0 
+                AND final_speed_knots <= 50 THEN distance_nm ELSE 0 END
+              ) AS total_distance_nm, 
+              (
+                SUM(distance_nm)
+              ) AS total_distance_nm_wo_filter, 
+              -- # Get distinct day count that a vessel transitted the VSR zone
+              COUNT(num) AS seg_count, 
+              COUNT(
+                DISTINCT (date)
+              ) AS day_count, 
+              -- # Check max and min speeds for:
+              -- # speed_knots (reported)
+              ROUND(
+                MAX(final_speed_knots), 
+                3
+              ) AS max_speed_knots, 
+              ROUND(
+                MIN(final_speed_knots), 
+                3
+              ) AS min_speed_knots, 
+              -- # implied_speed_knots (gfw calculated)
+              ROUND(
+                MAX(implied_speed_knots), 
+                3
+              ) AS max_implied_speed_knots, 
+              ROUND(
+                MIN(implied_speed_knots), 
+                3
+              ) AS min_implied_speed_knots, 
+              -- # Final calculated speed (most lenient among the implied_speed_knots (gfw calculated) and calculated_knots (BOI calculated speed))
+              MAX(final_speed_knots) AS max_final_calculated_speed_knots, 
+              MIN(final_speed_knots) AS min_final_calculated_speed_knots, 
+              MAX(timestamp_end) AS max_timestamp, 
+              MIN(timestamp_beg) AS min_timestamp, 
+              vsr_category, 
+              exclude_category 
+            FROM 
+              (
+                SELECT 
+                  ais.*, 
+                  cats.* 
+                EXCEPT 
+                  (shiptype) 
+                FROM 
+                  (
+                    SELECT 
+                      ais.*, 
+                      ihs.* 
+                    EXCEPT 
+                      (mmsi, gt) 
+                    FROM 
+                      `whalesafe_v3.ais_vsr_segments` AS ais 
+                      LEFT JOIN `whalesafe_v3.ihs_data_all` AS ihs ON ais.mmsi = ihs.mmsi 
+                    WHERE 
+                      (ais.timestamp) > '1990-01-01' --   AND touches_coast IS TRUE -- # touches_coast FILTER, UNCOMMENT IF NEEDED
+                      AND DATE(ais.timestamp_beg) >= (ihs.start_date) 
+                      AND DATE(ais.timestamp_end) <= (ihs.end_date)
+                  ) AS ais 
+                  LEFT JOIN `whalesafe_v3.shiptype_categories` cats ON TRIM(ais.ship_type) = TRIM(cats.shiptype) 
+                WHERE 
+                  ais.gt >= 300
+              ) 
+            GROUP BY 
+              mmsi, 
+              name_of_ship, 
+              operator, 
+              operator_code, 
+              technical_manager, 
+              ship_type, 
+              gt, 
+              date, 
+              vsr_region, 
+              ship_category, 
+              vsr_category, 
+              exclude_category
+          )
+      )
   )
-GROUP BY
-	mmsi, name_of_ship, operator, operator_code, technical_manager, ship_type, gt, date, vsr_region, ship_category, vsr_category, exclude_category)
+UNION ALL
+SELECT 
+  mmsi, 
+  name_of_ship, 
+  operator, 
+  operator_code, 
+  technical_manager, 
+  ship_type AS shiptype, 
+  ship_category, 
+  date, 
+  vsr_region, 
+  vsr_category, 
+  cooperation_score_daily, 
+  ROUND(
+    (coop_score_daily), 
+    2
+  ) AS coop_score_daily, 
+  CASE WHEN (coop_score_daily) >= 99 THEN 'A+' WHEN (coop_score_daily) < 99 
+  AND(coop_score_daily) >= 80 THEN 'A' WHEN (coop_score_daily) < 80 
+  AND(coop_score_daily) >= 60 THEN 'B' WHEN (coop_score_daily) < 60 
+  AND(coop_score_daily) >= 40 THEN 'C' WHEN (coop_score_daily) < 40 
+  AND(coop_score_daily) >= 20 THEN 'D' ELSE 'F' END AS coop_grade_daily, 
+  ROUND(
+    (
+      SAFE_DIVIDE(
+        cum_sum_total_distance_nm_under_10, 
+        cum_sum_total_distance_nm
+      ) * 100
+    ), 
+    2
+  ) AS rolling_coop_score, 
+  CASE WHEN (
+    ROUND(
+      (
+        SAFE_DIVIDE(
+          cum_sum_total_distance_nm_under_10, 
+          cum_sum_total_distance_nm
+        ) * 100
+      ), 
+      2
+    )
+  ) >= 99 THEN 'A+' WHEN (
+    ROUND(
+      (
+        SAFE_DIVIDE(
+          cum_sum_total_distance_nm_under_10, 
+          cum_sum_total_distance_nm
+        ) * 100
+      ), 
+      2
+    )
+  ) < 99 
+  AND(
+    ROUND(
+      (
+        SAFE_DIVIDE(
+          cum_sum_total_distance_nm_under_10, 
+          cum_sum_total_distance_nm
+        ) * 100
+      ), 
+      2
+    )
+  ) >= 80 THEN 'A' WHEN (
+    ROUND(
+      (
+        SAFE_DIVIDE(
+          cum_sum_total_distance_nm_under_10, 
+          cum_sum_total_distance_nm
+        ) * 100
+      ), 
+      2
+    )
+  ) < 80 
+  AND(
+    ROUND(
+      (
+        SAFE_DIVIDE(
+          cum_sum_total_distance_nm_under_10, 
+          cum_sum_total_distance_nm
+        ) * 100
+      ), 
+      2
+    )
+  ) >= 60 THEN 'B' WHEN (
+    ROUND(
+      (
+        SAFE_DIVIDE(
+          cum_sum_total_distance_nm_under_10, 
+          cum_sum_total_distance_nm
+        ) * 100
+      ), 
+      2
+    )
+  ) < 60 
+  AND(
+    ROUND(
+      (
+        SAFE_DIVIDE(
+          cum_sum_total_distance_nm_under_10, 
+          cum_sum_total_distance_nm
+        ) * 100
+      ), 
+      2
+    )
+  ) >= 40 THEN 'C' WHEN (
+    ROUND(
+      (
+        SAFE_DIVIDE(
+          cum_sum_total_distance_nm_under_10, 
+          cum_sum_total_distance_nm
+        ) * 100
+      ), 
+      2
+    )
+  ) < 40 
+  AND(
+    ROUND(
+      (
+        SAFE_DIVIDE(
+          cum_sum_total_distance_nm_under_10, 
+          cum_sum_total_distance_nm
+        ) * 100
+      ), 
+      2
+    )
+  ) >= 20 THEN 'D' ELSE 'F' END AS rolling_coop_grade, 
+  total_distance_nm, 
+  cum_sum_total_distance_nm, 
+  total_distance_nm_under_10, 
+  cum_sum_total_distance_nm_under_10, 
+  percent_under_10_knots, 
+  total_distance_nm_btwn_10_12, 
+  percent_10_12_knots, 
+  total_distance_nm_btwn_12_15, 
+  percent_12_15_knots, 
+  total_distance_nm_over_15, 
+  percent_over_15_knots, 
+  total_distance_nm_weird, 
+  total_distance_nm_wo_filter, 
+  avg_speed_knots, 
+  min_timestamp, 
+  max_timestamp, 
+  gt, 
+  day_count, 
+  seg_count, 
+  exclude_category 
+FROM 
+  (
+    SELECT 
+      --         ROUND(AVG(coop_score_daily) OVER (PARTITION BY mmsi, vsr_region, year ORDER BY mmsi, date, year), 3) AS rolling_coop_score,
+      ROUND(
+        SUM(total_distance_nm_under_10) OVER (
+          PARTITION BY mmsi, 
+          vsr_region, 
+          year 
+          ORDER BY 
+            mmsi, 
+            date, 
+            year
+        ), 
+        2
+      ) AS cum_sum_total_distance_nm_under_10, 
+      ROUND(
+        SUM(total_distance_nm) OVER (
+          PARTITION BY mmsi, 
+          vsr_region, 
+          year 
+          ORDER BY 
+            mmsi, 
+            date, 
+            year
+        ), 
+        2
+      ) AS cum_sum_total_distance_nm, 
+      * 
+    FROM 
+      (
+        SELECT 
+          mmsi, 
+          date, 
+          EXTRACT(
+            YEAR 
+            FROM 
+              date
+          ) AS year, 
+          vsr_region, 
+          name_of_ship, 
+          ship_type, 
+          IFNULL(ship_category, "OTHER") AS ship_category, 
+          operator, 
+          operator_code, 
+          technical_manager, 
+          -- # Get cooperation score
+          CONCAT(
+            (
+              ROUND(
+                SAFE_DIVIDE(
+                  total_distance_nm_under_10, total_distance_nm
+                ) * 100, 
+                2
+              )
+            ), 
+            '%'
+          ) AS cooperation_score_daily, 
+          ROUND(
+            (
+              SAFE_DIVIDE(
+                total_distance_nm_under_10, total_distance_nm
+              ) * 100
+            ), 
+            2
+          ) AS coop_score_daily, 
+          -- # Show distances km in each speed bin and Calculate percentages for distances travelled in each speed bin
+          ROUND(total_distance_nm_under_10, 2) total_distance_nm_under_10, 
+          CONCAT(
+            ROUND(
+              SAFE_DIVIDE(
+                total_distance_nm_under_10, total_distance_nm
+              ) * 100, 
+              1
+            ), 
+            '%'
+          ) AS percent_under_10_knots, 
+          --
+          ROUND(total_distance_nm_btwn_10_12, 2) total_distance_nm_btwn_10_12, 
+          CONCAT(
+            ROUND(
+              SAFE_DIVIDE(
+                total_distance_nm_btwn_10_12, total_distance_nm
+              ) * 100, 
+              1
+            ), 
+            '%'
+          ) AS percent_10_12_knots, 
+          --
+          ROUND(total_distance_nm_btwn_12_15, 2) total_distance_nm_btwn_12_15, 
+          CONCAT(
+            ROUND(
+              SAFE_DIVIDE(
+                total_distance_nm_btwn_12_15, total_distance_nm
+              ) * 100, 
+              1
+            ), 
+            '%'
+          ) AS percent_12_15_knots, 
+          --
+          ROUND(total_distance_nm_over_15, 2) total_distance_nm_over_15, 
+          CONCAT(
+            ROUND(
+              SAFE_DIVIDE(
+                total_distance_nm_over_15, total_distance_nm
+              ) * 100, 
+              1
+            ), 
+            '%'
+          ) AS percent_over_15_knots, 
+          -- # Show total distance traveled in VSR ZONE
+          ROUND(total_distance_nm, 2) total_distance_nm, 
+          day_count, 
+          seg_count, 
+          -- # Show total distance traveled at speeds > 60 or speeds < 0 in VSR ZONE
+          total_distance_nm_weird, 
+          total_distance_nm_wo_filter, 
+          -- # Average speed
+          avg_speed_knots, 
+          -- # Max and Min speeds in reported, implied, calculated, and lenient speeds
+          max_speed_knots, 
+          min_speed_knots, 
+          max_implied_speed_knots, 
+          min_implied_speed_knots, 
+          max_final_calculated_speed_knots, 
+          min_final_calculated_speed_knots, 
+          max_timestamp, 
+          min_timestamp, 
+          gt, 
+          vsr_category, 
+          exclude_category 
+        FROM 
+          (
+            SELECT 
+              DISTINCT(mmsi), 
+              date, 
+              'aggregated' as vsr_region, 
+              name_of_ship, 
+              ship_type, 
+              ship_category, 
+              operator, 
+              operator_code, 
+              technical_manager, 
+              gt, 
+              -- # Average speed in knots
+              ROUND(
+                AVG(final_speed_knots), 
+                2
+              ) AS avg_speed_knots, 
+              -- # Total distance in km where speed <= 10 knots
+              -- # A little weirdness with there being distance travelled at 0 knots...
+              SUM(
+                CASE WHEN final_speed_knots > 0 
+                AND final_speed_knots <= 10 THEN (
+                  (distance_nm)
+                ) ELSE 0 END
+              ) AS total_distance_nm_under_10, 
+              -- # Total distance in km where speed > 10 knots and <= 12 knots
+              SUM(
+                CASE WHEN final_speed_knots > 10 
+                AND final_speed_knots <= 12 THEN (
+                  (distance_nm)
+                ) ELSE 0 END
+              ) AS total_distance_nm_btwn_10_12, 
+              -- # Total distance in km where speed > 12 knots and <= 15 knots
+              SUM(
+                CASE WHEN final_speed_knots > 12 
+                AND final_speed_knots <= 15 THEN (
+                  (distance_nm)
+                ) ELSE 0 END
+              ) AS total_distance_nm_btwn_12_15, 
+              -- # Total distance in km where speed > 15 knots
+              SUM(
+                CASE WHEN final_speed_knots > 15 
+                AND final_speed_knots <= 50 THEN (
+                  (distance_nm)
+                ) ELSE 0 END
+              ) AS total_distance_nm_over_15, 
+              -- # Checking for weird speeds from edge cases
+              SUM(
+                CASE WHEN final_speed_knots <= 0 
+                AND final_speed_knots > 50 
+                OR final_speed_knots IS NULL THEN distance_nm ELSE 0 END
+              ) AS total_distance_nm_weird, 
+              SUM(
+                CASE WHEN final_speed_knots > 0 
+                AND final_speed_knots <= 50 THEN distance_nm ELSE 0 END
+              ) AS total_distance_nm, 
+              (
+                SUM(distance_nm)
+              ) AS total_distance_nm_wo_filter, 
+              -- # Get distinct day count that a vessel transitted the VSR zone
+              COUNT(num) AS seg_count, 
+              COUNT(
+                DISTINCT (date)
+              ) AS day_count, 
+              -- # Check max and min speeds for:
+              -- # speed_knots (reported)
+              ROUND(
+                MAX(final_speed_knots), 
+                3
+              ) AS max_speed_knots, 
+              ROUND(
+                MIN(final_speed_knots), 
+                3
+              ) AS min_speed_knots, 
+              -- # implied_speed_knots (gfw calculated)
+              ROUND(
+                MAX(implied_speed_knots), 
+                3
+              ) AS max_implied_speed_knots, 
+              ROUND(
+                MIN(implied_speed_knots), 
+                3
+              ) AS min_implied_speed_knots, 
+              -- # Final calculated speed (most lenient among the implied_speed_knots (gfw calculated) and calculated_knots (BOI calculated speed))
+              MAX(final_speed_knots) AS max_final_calculated_speed_knots, 
+              MIN(final_speed_knots) AS min_final_calculated_speed_knots, 
+              MAX(timestamp_end) AS max_timestamp, 
+              MIN(timestamp_beg) AS min_timestamp, 
+              vsr_category, 
+              exclude_category 
+            FROM 
+              (
+                SELECT 
+                  ais.*, 
+                  cats.* 
+                EXCEPT 
+                  (shiptype) 
+                FROM 
+                  (
+                    SELECT 
+                      ais.*, 
+                      ihs.* 
+                    EXCEPT 
+                      (mmsi, gt) 
+                    FROM 
+                      `whalesafe_v3.ais_vsr_segments` AS ais 
+                      LEFT JOIN `whalesafe_v3.ihs_data_all` AS ihs ON ais.mmsi = ihs.mmsi 
+                    WHERE 
+                      (ais.timestamp) > '1990-01-01' --   AND touches_coast IS TRUE -- # touches_coast FILTER, UNCOMMENT IF NEEDED
+                      AND DATE(ais.timestamp_beg) >= (ihs.start_date) 
+                      AND DATE(ais.timestamp_end) <= (ihs.end_date)
+                  ) AS ais 
+                  LEFT JOIN `whalesafe_v3.shiptype_categories` cats ON TRIM(ais.ship_type) = TRIM(cats.shiptype) 
+                WHERE 
+                  ais.gt >= 300
+                  AND (ais.vsr_region = 'sc' OR ais.vsr_region = 'sf')
+              ) 
+            GROUP BY 
+              mmsi, 
+              name_of_ship, 
+              operator, 
+              operator_code, 
+              technical_manager, 
+              ship_type, 
+              gt, 
+              date,
+              ship_category, 
+              vsr_category, 
+              exclude_category
+          )
+      )
   )
-)
-;
+
 
 -- -- # -- Step 2: Create a timestamp log to track newest timestamps in stats data.
 CREATE TABLE IF NOT EXISTS `whalesafe_v3.stats_log` (
-      newest_timestamp TIMESTAMP,
-      newest_date DATE,
-			date_accessed TIMESTAMP,
-			table_name STRING);
-
+  newest_timestamp TIMESTAMP, newest_date DATE, 
+  date_accessed TIMESTAMP, table_name STRING
+);
 -- # -- Step 3: Insert newest timestamp into log
-INSERT INTO `whalesafe_v3.stats_log`
-SELECT
-	(
-		SELECT
-			MAX(max_timestamp)
-		FROM
-			`whalesafe_v3.ship_stats_daily`
-		LIMIT 1) AS newest_timestamp,
-    (
-		SELECT
-			MAX(date)
-		FROM
-			`whalesafe_v3.ship_stats_daily`
-		LIMIT 1) AS newest_date,
-	CURRENT_TIMESTAMP() AS date_accessed,
-	'ship_stats_daily' AS table_name;
-
+INSERT INTO `whalesafe_v3.stats_log` 
+SELECT 
+  (
+    SELECT 
+      MAX(max_timestamp) 
+    FROM 
+      `whalesafe_v3.ship_stats_daily` 
+    LIMIT 
+      1
+  ) AS newest_timestamp, 
+  (
+    SELECT 
+      MAX(date) 
+    FROM 
+      `whalesafe_v3.ship_stats_daily` 
+    LIMIT 
+      1
+  ) AS newest_date, 
+  CURRENT_TIMESTAMP() AS date_accessed, 
+  'ship_stats_daily' AS table_name;

--- a/sql_v3_scheduled-on-BigQuery/update_whalesafe_v3_ship_stats_daily.sql
+++ b/sql_v3_scheduled-on-BigQuery/update_whalesafe_v3_ship_stats_daily.sql
@@ -418,8 +418,8 @@ FROM
               exclude_category
           )
       )
-  )
-UNION ALL
+  ) 
+UNION ALL 
 SELECT 
   mmsi, 
   name_of_ship, 
@@ -811,8 +811,11 @@ FROM
                   ) AS ais 
                   LEFT JOIN `whalesafe_v3.shiptype_categories` cats ON TRIM(ais.ship_type) = TRIM(cats.shiptype) 
                 WHERE 
-                  ais.gt >= 300
-                  AND (ais.vsr_region = 'sc' OR ais.vsr_region = 'sf')
+                  ais.gt >= 300 
+                  AND (
+                    ais.vsr_region = 'sc' 
+                    OR ais.vsr_region = 'sf'
+                  )
               ) 
             GROUP BY 
               mmsi, 
@@ -822,20 +825,17 @@ FROM
               technical_manager, 
               ship_type, 
               gt, 
-              date,
+              date, 
               ship_category, 
               vsr_category, 
               exclude_category
           )
       )
-  )
-
-
--- -- # -- Step 2: Create a timestamp log to track newest timestamps in stats data.
-CREATE TABLE IF NOT EXISTS `whalesafe_v3.stats_log` (
-  newest_timestamp TIMESTAMP, newest_date DATE, 
-  date_accessed TIMESTAMP, table_name STRING
-);
+  ) -- -- # -- Step 2: Create a timestamp log to track newest timestamps in stats data.
+  CREATE TABLE IF NOT EXISTS `whalesafe_v3.stats_log` (
+    newest_timestamp TIMESTAMP, newest_date DATE, 
+    date_accessed TIMESTAMP, table_name STRING
+  );
 -- # -- Step 3: Insert newest timestamp into log
 INSERT INTO `whalesafe_v3.stats_log` 
 SELECT 

--- a/sql_v3_scheduled-on-BigQuery/update_whalesafe_v3_ship_stats_monthly.sql
+++ b/sql_v3_scheduled-on-BigQuery/update_whalesafe_v3_ship_stats_monthly.sql
@@ -1,174 +1,309 @@
 -- # -- # Updating `whalesafe_v3.ship_stats_monthly` -- # --
 -- # Benioff Ocean Initiative: 2020-07-30
 -- # -- Needs `ship_stats_daily` to run.
-
 -- # -- Step 0: Drop existing `ship_stats_monthly` table.
-DROP TABLE IF EXISTS `whalesafe_v3.ship_stats_monthly`;
-
+DROP 
+  TABLE IF EXISTS `whalsafe_v3.ship_stats_monthly`;
 -- -- -- -- # -- Step 1: Create Updated ship_stats_monthly table.
-CREATE TABLE IF NOT EXISTS `whalesafe_v3.ship_stats_monthly`
-CLUSTER BY mmsi, operator, coop_score_monthly, vsr_region
-AS
-SELECT
-mmsi,
-name_of_ship,
-operator,
-operator_code,
-technical_manager,
-shiptype,
-ship_category,
-vsr_region,
-month,
-year,
-coop_score_monthly,
-month_grade,
-rolling_coop_score,
-rolling_month_grade,
-total_distance_nm,
-cum_sum_total_distance_nm,
-total_distance_nm_under_10,
-cum_sum_total_distance_nm_under_10,
-percent_distance_under_10,
-total_distance_nm_btwn_10_12,
-percent_distance_btwn_10_12,
-total_distance_nm_btwn_12_15,
-percent_distance_btwn_12_15,
-total_distance_nm_over_15,
-percent_distance_over_15,
-avg_speed_knots,
-min_timestamp,
-max_timestamp,
-gt,
-day_count,
-seg_count,
-exclude_category
-FROM(
-SELECT
-CASE
-    WHEN (rolling_coop_score) >= 99 THEN
-					'A+'
-				WHEN (rolling_coop_score) < 99
-		AND (rolling_coop_score) >= 80 THEN
-					'A'
-				WHEN (rolling_coop_score) < 80
-		AND(rolling_coop_score) >= 60 THEN
-					'B'
-				WHEN (rolling_coop_score) < 60
-		AND(rolling_coop_score) >= 40 THEN
-					'C'
-				WHEN (rolling_coop_score) < 40
-		AND(rolling_coop_score) >= 20 THEN
-					'D'
-    ELSE
-      'F'
-    END AS rolling_month_grade,
-    *
-FROM(
-SELECT
-    mmsi, name_of_ship,
-    operator, operator_code, technical_manager,
-    shiptype, ship_category, vsr_region,
-    month, year,
-    coop_score_monthly,
-    CASE
-    WHEN ((total_distance_nm_under_10 / total_distance_nm) * 100) >= 99 THEN
-					'A+'
-				WHEN ((total_distance_nm_under_10 / total_distance_nm) * 100) < 99
-		AND((total_distance_nm_under_10 / total_distance_nm) * 100) >= 80 THEN
-					'A'
-				WHEN ((total_distance_nm_under_10 / total_distance_nm) * 100) < 80
-		AND((total_distance_nm_under_10 / total_distance_nm) * 100) >= 60 THEN
-					'B'
-				WHEN ((total_distance_nm_under_10 / total_distance_nm) * 100) < 60
-		AND((total_distance_nm_under_10 / total_distance_nm) * 100) >= 40 THEN
-					'C'
-				WHEN ((total_distance_nm_under_10 / total_distance_nm) * 100) < 40
-		AND((total_distance_nm_under_10 / total_distance_nm) * 100) >= 20 THEN
-					'D'
-    ELSE
-      'F'
-    END AS month_grade,
-    ROUND((ROUND(SUM(total_distance_nm_under_10) OVER (PARTITION BY mmsi, vsr_region, year ORDER BY mmsi, month, year ROWS BETWEEN 12 PRECEDING AND CURRENT ROW), 2) / ROUND(SUM(total_distance_nm) OVER (PARTITION BY mmsi, vsr_region, year ORDER BY mmsi, month, year ROWS BETWEEN 12 PRECEDING AND CURRENT ROW), 2) * 100),2) AS rolling_coop_score,
-    ROUND(total_distance_nm, 2) AS total_distance_nm,
-    ROUND(SUM(total_distance_nm) OVER (PARTITION BY mmsi, vsr_region, year ORDER BY mmsi, month, year ROWS BETWEEN 12 PRECEDING AND CURRENT ROW), 2) AS cum_sum_total_distance_nm,
-    ROUND(total_distance_nm_under_10, 2) AS total_distance_nm_under_10,
-    ROUND(SUM(total_distance_nm_under_10) OVER (PARTITION BY mmsi, vsr_region, year ORDER BY mmsi, month, year ROWS BETWEEN 12 PRECEDING AND CURRENT ROW), 2) AS cum_sum_total_distance_nm_under_10,
-    CONCAT(ROUND(((total_distance_nm_under_10 / total_distance_nm)*100), 2), '%') AS percent_distance_under_10,
-    ROUND(total_distance_nm_btwn_10_12, 2) AS total_distance_nm_btwn_10_12,
-    CONCAT(ROUND(((total_distance_nm_btwn_10_12 / total_distance_nm)*100), 2), '%') AS percent_distance_btwn_10_12,
-    ROUND(total_distance_nm_btwn_12_15, 2) AS total_distance_nm_btwn_12_15,
-    CONCAT(ROUND(((total_distance_nm_btwn_12_15 / total_distance_nm)*100), 2), '%') AS percent_distance_btwn_12_15,
-    ROUND(total_distance_nm_over_15, 2) AS total_distance_nm_over_15,
-    CONCAT(ROUND(((total_distance_nm_over_15 / total_distance_nm)*100), 2), '%') AS percent_distance_over_15,
-    ROUND(avg_speed_knots, 2) AS avg_speed_knots,
-    min_timestamp, max_timestamp,
-    gt, day_count, seg_count, exclude_category
-FROM(
-SELECT
-mmsi,
-name_of_ship,
-operator,
-operator_code,
-technical_manager,
-shiptype,
-ship_category,
-vsr_region,
-EXTRACT(MONTH FROM date) AS month,
-EXTRACT(YEAR FROM date) AS year,
-ROUND(((SUM(total_distance_nm_under_10) / SUM(total_distance_nm))*100), 2) AS coop_score_monthly,
-SUM(total_distance_nm) AS total_distance_nm ,
-SUM(total_distance_nm_under_10) AS total_distance_nm_under_10 ,
-SUM(total_distance_nm_btwn_10_12) AS total_distance_nm_btwn_10_12 ,
-SUM(total_distance_nm_btwn_12_15) AS total_distance_nm_btwn_12_15 ,
-SUM(total_distance_nm_over_15) AS total_distance_nm_over_15 ,
-AVG( avg_speed_knots ) AS avg_speed_knots,
-MIN(min_timestamp) AS min_timestamp ,
-MAX(max_timestamp) AS max_timestamp ,
-gt,
-SUM(day_count) AS day_count ,
-SUM(seg_count) AS seg_count ,
-exclude_category
-FROM `whalesafe_v3.ship_stats_daily`
-WHERE vsr_category NOT LIKE '%off%'
-GROUP BY
-mmsi,
-name_of_ship,
-operator,
-operator_code,
-technical_manager,
-shiptype,
-ship_category,
-vsr_region,
-month,
-year,
-gt,
-exclude_category
-)
-)
-)
-;
-
+CREATE TABLE IF NOT EXISTS `whalsafe_v3.ship_stats_monthly` CLUSTER BY mmsi, 
+operator, 
+coop_score_monthly, 
+vsr_region AS 
+SELECT 
+  mmsi, 
+  name_of_ship, 
+  operator, 
+  operator_code, 
+  technical_manager, 
+  shiptype, 
+  ship_category, 
+  vsr_region, 
+  month, 
+  year, 
+  coop_score_monthly, 
+  month_grade, 
+  rolling_coop_score, 
+  rolling_month_grade, 
+  total_distance_nm, 
+  cum_sum_total_distance_nm, 
+  total_distance_nm_under_10, 
+  cum_sum_total_distance_nm_under_10, 
+  percent_distance_under_10, 
+  total_distance_nm_btwn_10_12, 
+  percent_distance_btwn_10_12, 
+  total_distance_nm_btwn_12_15, 
+  percent_distance_btwn_12_15, 
+  total_distance_nm_over_15, 
+  percent_distance_over_15, 
+  avg_speed_knots, 
+  min_timestamp, 
+  max_timestamp, 
+  gt, 
+  day_count, 
+  seg_count, 
+  exclude_category 
+FROM 
+  (
+    SELECT 
+      CASE WHEN (rolling_coop_score) >= 99 THEN 'A+' WHEN (rolling_coop_score) < 99 
+      AND (rolling_coop_score) >= 80 THEN 'A' WHEN (rolling_coop_score) < 80 
+      AND(rolling_coop_score) >= 60 THEN 'B' WHEN (rolling_coop_score) < 60 
+      AND(rolling_coop_score) >= 40 THEN 'C' WHEN (rolling_coop_score) < 40 
+      AND(rolling_coop_score) >= 20 THEN 'D' ELSE 'F' END AS rolling_month_grade, 
+      * 
+    FROM 
+      (
+        SELECT 
+          mmsi, 
+          name_of_ship, 
+          operator, 
+          operator_code, 
+          technical_manager, 
+          shiptype, 
+          ship_category, 
+          vsr_region, 
+          month, 
+          year, 
+          coop_score_monthly, 
+          CASE WHEN (
+            (
+              total_distance_nm_under_10 / total_distance_nm
+            ) * 100
+          ) >= 99 THEN 'A+' WHEN (
+            (
+              total_distance_nm_under_10 / total_distance_nm
+            ) * 100
+          ) < 99 
+          AND(
+            (
+              total_distance_nm_under_10 / total_distance_nm
+            ) * 100
+          ) >= 80 THEN 'A' WHEN (
+            (
+              total_distance_nm_under_10 / total_distance_nm
+            ) * 100
+          ) < 80 
+          AND(
+            (
+              total_distance_nm_under_10 / total_distance_nm
+            ) * 100
+          ) >= 60 THEN 'B' WHEN (
+            (
+              total_distance_nm_under_10 / total_distance_nm
+            ) * 100
+          ) < 60 
+          AND(
+            (
+              total_distance_nm_under_10 / total_distance_nm
+            ) * 100
+          ) >= 40 THEN 'C' WHEN (
+            (
+              total_distance_nm_under_10 / total_distance_nm
+            ) * 100
+          ) < 40 
+          AND(
+            (
+              total_distance_nm_under_10 / total_distance_nm
+            ) * 100
+          ) >= 20 THEN 'D' ELSE 'F' END AS month_grade, 
+          ROUND(
+            (
+              ROUND(
+                SUM(total_distance_nm_under_10) OVER (
+                  PARTITION BY mmsi, 
+                  vsr_region, 
+                  year 
+                  ORDER BY 
+                    mmsi, 
+                    month, 
+                    year ROWS BETWEEN 12 PRECEDING 
+                    AND CURRENT ROW
+                ), 
+                2
+              ) / ROUND(
+                SUM(total_distance_nm) OVER (
+                  PARTITION BY mmsi, 
+                  vsr_region, 
+                  year 
+                  ORDER BY 
+                    mmsi, 
+                    month, 
+                    year ROWS BETWEEN 12 PRECEDING 
+                    AND CURRENT ROW
+                ), 
+                2
+              ) * 100
+            ), 
+            2
+          ) AS rolling_coop_score, 
+          ROUND(total_distance_nm, 2) AS total_distance_nm, 
+          ROUND(
+            SUM(total_distance_nm) OVER (
+              PARTITION BY mmsi, 
+              vsr_region, 
+              year 
+              ORDER BY 
+                mmsi, 
+                month, 
+                year ROWS BETWEEN 12 PRECEDING 
+                AND CURRENT ROW
+            ), 
+            2
+          ) AS cum_sum_total_distance_nm, 
+          ROUND(total_distance_nm_under_10, 2) AS total_distance_nm_under_10, 
+          ROUND(
+            SUM(total_distance_nm_under_10) OVER (
+              PARTITION BY mmsi, 
+              vsr_region, 
+              year 
+              ORDER BY 
+                mmsi, 
+                month, 
+                year ROWS BETWEEN 12 PRECEDING 
+                AND CURRENT ROW
+            ), 
+            2
+          ) AS cum_sum_total_distance_nm_under_10, 
+          CONCAT(
+            ROUND(
+              (
+                (
+                  total_distance_nm_under_10 / total_distance_nm
+                )* 100
+              ), 
+              2
+            ), 
+            '%'
+          ) AS percent_distance_under_10, 
+          ROUND(total_distance_nm_btwn_10_12, 2) AS total_distance_nm_btwn_10_12, 
+          CONCAT(
+            ROUND(
+              (
+                (
+                  total_distance_nm_btwn_10_12 / total_distance_nm
+                )* 100
+              ), 
+              2
+            ), 
+            '%'
+          ) AS percent_distance_btwn_10_12, 
+          ROUND(total_distance_nm_btwn_12_15, 2) AS total_distance_nm_btwn_12_15, 
+          CONCAT(
+            ROUND(
+              (
+                (
+                  total_distance_nm_btwn_12_15 / total_distance_nm
+                )* 100
+              ), 
+              2
+            ), 
+            '%'
+          ) AS percent_distance_btwn_12_15, 
+          ROUND(total_distance_nm_over_15, 2) AS total_distance_nm_over_15, 
+          CONCAT(
+            ROUND(
+              (
+                (
+                  total_distance_nm_over_15 / total_distance_nm
+                )* 100
+              ), 
+              2
+            ), 
+            '%'
+          ) AS percent_distance_over_15, 
+          ROUND(avg_speed_knots, 2) AS avg_speed_knots, 
+          min_timestamp, 
+          max_timestamp, 
+          gt, 
+          day_count, 
+          seg_count, 
+          exclude_category 
+        FROM 
+          (
+            SELECT 
+              mmsi, 
+              name_of_ship, 
+              operator, 
+              operator_code, 
+              technical_manager, 
+              shiptype, 
+              ship_category, 
+              vsr_region, 
+              EXTRACT(
+                MONTH 
+                FROM 
+                  date
+              ) AS month, 
+              EXTRACT(
+                YEAR 
+                FROM 
+                  date
+              ) AS year, 
+              ROUND(
+                (
+                  (
+                    SUM(total_distance_nm_under_10) / SUM(total_distance_nm)
+                  )* 100
+                ), 
+                2
+              ) AS coop_score_monthly, 
+              SUM(total_distance_nm) AS total_distance_nm, 
+              SUM(total_distance_nm_under_10) AS total_distance_nm_under_10, 
+              SUM(total_distance_nm_btwn_10_12) AS total_distance_nm_btwn_10_12, 
+              SUM(total_distance_nm_btwn_12_15) AS total_distance_nm_btwn_12_15, 
+              SUM(total_distance_nm_over_15) AS total_distance_nm_over_15, 
+              AVG(avg_speed_knots) AS avg_speed_knots, 
+              MIN(min_timestamp) AS min_timestamp, 
+              MAX(max_timestamp) AS max_timestamp, 
+              gt, 
+              SUM(day_count) AS day_count, 
+              SUM(seg_count) AS seg_count, 
+              exclude_category 
+            FROM 
+              `whalsafe_v3.ship_stats_daily` 
+            WHERE 
+              vsr_category NOT LIKE '%off%' 
+            GROUP BY 
+              mmsi, 
+              name_of_ship, 
+              operator, 
+              operator_code, 
+              technical_manager, 
+              shiptype, 
+              ship_category, 
+              vsr_region, 
+              month, 
+              year, 
+              gt, 
+              exclude_category
+          )
+      )
+  );
 # -- Step 2: Create a timestamp log to track newest timestamps in stats data.
-CREATE TABLE IF NOT EXISTS `whalesafe_v3.stats_log` (
-      newest_timestamp TIMESTAMP,
-      newest_date DATE,
-			date_accessed TIMESTAMP,
-			table_name STRING);
-
+CREATE TABLE IF NOT EXISTS `whalsafe_v3.stats_log` (
+  newest_timestamp TIMESTAMP, newest_date DATE, 
+  date_accessed TIMESTAMP, table_name STRING
+);
 -- -- -- # -- Step 3: Insert newest timestamp into log
-INSERT INTO `whalesafe_v3.stats_log`
-SELECT
-	(
-		SELECT
-			MAX(max_timestamp)
-		FROM
-			`whalesafe_v3.ship_stats_monthly`
-		LIMIT 1) AS newest_timestamp,
-    (
-		SELECT
-			DATE(MAX(max_timestamp))
-		FROM
-			`whalesafe_v3.ship_stats_monthly`
-		LIMIT 1) AS newest_date,
-	 CURRENT_TIMESTAMP() AS date_accessed,
-	'ship_stats_monthly' AS table_name;
+INSERT INTO `whalsafe_v3.stats_log` 
+SELECT 
+  (
+    SELECT 
+      MAX(max_timestamp) 
+    FROM 
+      `whalsafe_v3.ship_stats_monthly` 
+    LIMIT 
+      1
+  ) AS newest_timestamp, 
+  (
+    SELECT 
+      DATE(
+        MAX(max_timestamp)
+      ) 
+    FROM 
+      `whalsafe_v3.ship_stats_monthly` 
+    LIMIT 
+      1
+  ) AS newest_date, 
+  CURRENT_TIMESTAMP() AS date_accessed, 
+  'ship_stats_monthly' AS table_name;


### PR DESCRIPTION
This code creates a new vsr_region in ship_stats_daily which carries through the following aggregations including: ship_stats_monthly, ship_stats_yearly, operator_stats_daily, operator_stats_monthly, operator_stats_yearly

In order to accomplish this, I created a second select statement which mimics the original but filters on the 'sf' and 'sc' vsr_regions. It also leaves out the grouping by vsr_region so that the SUM functions include both entries (sf and sc) in their calculation. The vsr_region is then hardcoded as 'aggregated'. Our API should allow us to pass this as the new vsr_region to get the aggregated operator stats annual.

Testing:
This code was tested by creating a test dataset in BQ called aggregated_sf_sc_scores and manually queried to compare results against original dataset incorporating newly expected results.

Reviewing:
You only need to review the first commit "Added aggregated scores as new vsr_region". The second commit reformats the queries to be a little better, but would not be a good way to see the actual changes. Go to the commits tab and click on the first commit to view the actual changes.